### PR TITLE
Liberty Upgrade

### DIFF
--- a/manifests/openstack/cinder.pp
+++ b/manifests/openstack/cinder.pp
@@ -72,7 +72,6 @@ class profile::openstack::cinder {
   }
 
   class { '::cinder::scheduler':
-    scheduler_driver => 'cinder.scheduler.simple.SimpleScheduler',
     enabled          => true,
   }
   

--- a/manifests/openstack/cinder.pp
+++ b/manifests/openstack/cinder.pp
@@ -42,7 +42,6 @@ class profile::openstack::cinder {
     rabbit_host         => $rabbit_ip,
     rabbit_userid       => $rabbit_user,
     rabbit_password     => $rabbit_pass,
-    mysql_module        => '2.2',
   }
   
   class  { '::cinder::keystone::auth':

--- a/manifests/openstack/glance.pp
+++ b/manifests/openstack/glance.pp
@@ -71,7 +71,6 @@ class profile::openstack::glance {
     auth_host           => $admin_ip,
     keystone_tenant     => 'services',
     keystone_user       => 'glance',
-    mysql_module        => '2.2',
     before              => Anchor['profile::openstack::glance::end'],
     require             => Anchor['profile::openstack::glance::begin'],
   }

--- a/manifests/openstack/novacompute.pp
+++ b/manifests/openstack/novacompute.pp
@@ -67,8 +67,8 @@ class profile::openstack::novacompute {
   class { '::nova::compute::libvirt':
     libvirt_virt_type  => $nova_libvirt_type,
     vncserver_listen   => $management_ip,
-    libvirt_cpu_mode   => "custom",
-    libvirt_cpu_model' => $nova_libvirt_model,
+    libvirt_cpu_mode   => 'custom',
+    libvirt_cpu_model  => $nova_libvirt_model,
   }
 
   class { '::nova::compute::rbd':

--- a/manifests/openstack/novacompute.pp
+++ b/manifests/openstack/novacompute.pp
@@ -35,7 +35,6 @@ class profile::openstack::novacompute {
     rabbit_host         => $rabbit_ip,
     rabbit_userid       => $rabbit_user,
     rabbit_password     => $rabbit_pass,
-    mysql_module        => '2.2',
   }
 
   exec { "/usr/bin/ceph osd pool create volumes 4096" :

--- a/manifests/openstack/novacompute.pp
+++ b/manifests/openstack/novacompute.pp
@@ -61,16 +61,14 @@ class profile::openstack::novacompute {
   }
 
   ceph_config {
-      'client.nova/key':              value => $nova_key;
+    'client.nova/key':              value => $nova_key;
   }
 
   class { '::nova::compute::libvirt':
-    libvirt_virt_type => $nova_libvirt_type,
-    vncserver_listen  => $management_ip,
-	libvirt_cpu_mode => "custom",
-  }
-  nova_config {
-    'libvirt/cpu_model':   value => $nova_libvirt_model;
+    libvirt_virt_type  => $nova_libvirt_type,
+    vncserver_listen   => $management_ip,
+    libvirt_cpu_mode   => "custom",
+    libvirt_cpu_model' => $nova_libvirt_model;
   }
 
   class { '::nova::compute::rbd':

--- a/manifests/openstack/novacompute.pp
+++ b/manifests/openstack/novacompute.pp
@@ -68,7 +68,7 @@ class profile::openstack::novacompute {
     libvirt_virt_type  => $nova_libvirt_type,
     vncserver_listen   => $management_ip,
     libvirt_cpu_mode   => "custom",
-    libvirt_cpu_model' => $nova_libvirt_model;
+    libvirt_cpu_model' => $nova_libvirt_model,
   }
 
   class { '::nova::compute::rbd':


### PR DESCRIPTION
This pull-request contains all the changes needed to upgrade to liberty.

WARNING:
 When upgrading from Kilo to Liberty the command "nova-manage db migrate_flavour_data" needs to be run first to prepare the database for the migration.