### PR TITLE
LDAP support

### DIFF
--- a/example/hieradata/common.yaml.1controller
+++ b/example/hieradata/common.yaml.1controller
@@ -94,6 +94,14 @@ profile::keystone::admin_email: "post@localhost"
 profile::keystone::admin_password: '<pwgen>'
 profile::keystone::tokenflush::host: 'controller01'
 
+profile::keystone::ldap_backend::name: '<AD NetBIOS name>'
+profile::keystone::ldap_backend::url: 'ldap://<domain-FQDN>'
+profile::keystone::ldap_backend::user: '<DN for LDAP bind user>'
+profile::keystone::ldap_backend::password: '<password for LDAP bind user>'
+profile::keystone::ldap_backend::suffix: '<DN of domain-FQDN> (i.e DC=example,DC=com)'
+profile::keystone::ldap_backend::user_tree_dn: '<DN for user OU>'
+profile::keystone::ldap_backend::user_filter: '[optional] <ldap user filter>'
+
 profile::nova::sharedmetadataproxysecret: '<pwgen>'
 profile::nova::keystone::password: '<pwgen>'
 profile::nova::libvirt_type: 'kvm'

--- a/example/hieradata/common.yaml.3controller
+++ b/example/hieradata/common.yaml.3controller
@@ -102,6 +102,14 @@ profile::keystone::admin_email: "post@localhost"
 profile::keystone::admin_password: '<pwgen>'
 profile::keystone::tokenflush::host: 'controller01'
 
+profile::keystone::ldap_backend::name: '<AD NetBIOS name>'
+profile::keystone::ldap_backend::url: 'ldap://<domain-FQDN>'
+profile::keystone::ldap_backend::user: '<DN for LDAP bind user>'
+profile::keystone::ldap_backend::password: '<password for LDAP bind user>'
+profile::keystone::ldap_backend::suffix: '<DN of domain-FQDN> (i.e DC=example,DC=com)'
+profile::keystone::ldap_backend::user_tree_dn: '<DN for user OU>'
+profile::keystone::ldap_backend::user_filter: '[optional] <ldap user filter>'
+
 profile::nova::sharedmetadataproxysecret: '<pwgen>'
 profile::nova::keystone::password: '<pwgen>'
 profile::nova::libvirt_type: 'kvm'

--- a/manifests/baseconfig.pp
+++ b/manifests/baseconfig.pp
@@ -46,6 +46,7 @@ class profile::baseconfig {
   include ::nova::client
   include ::neutron::client
   include ::glance::client
+  include ::profile::openstack::repo
 
   class { '::ntp':
     servers   => [ 'ntp.hig.no'],

--- a/manifests/openstack/horizon.pp
+++ b/manifests/openstack/horizon.pp
@@ -36,15 +36,17 @@ class profile::openstack::horizon {
     content => "${ssl_ca}",
   } ->
   class { '::horizon':
-    allowed_hosts   => concat(['127.0.0.1', $::fqdn, $horizon_ip ], $controller_api, $horizon_allowed_hosts),
-    server_aliases  => concat(['127.0.0.1', $::fqdn, $horizon_ip ], $controller_api, $horizon_server_aliases),
-    secret_key      => $django_secret,
-    cache_server_ip => $memcache_ip,
-    listen_ssl      => true,
-    servername      => $server_name,
-    horizon_cert    => '/etc/ssl/certs/horizon.crt',
-    horizon_key     => '/etc/ssl/private/horizon.key',
-    horizon_ca      => '/etc/ssl/certs/CA.crt',
+    allowed_hosts                => concat(['127.0.0.1', $::fqdn, $horizon_ip ], $controller_api, $horizon_allowed_hosts),
+    server_aliases               => concat(['127.0.0.1', $::fqdn, $horizon_ip ], $controller_api, $horizon_server_aliases),
+    secret_key                   => $django_secret,
+    cache_server_ip              => $memcache_ip,
+    listen_ssl                   => true,
+    servername                   => $server_name,
+    horizon_cert                 => '/etc/ssl/certs/horizon.crt',
+    horizon_key                  => '/etc/ssl/private/horizon.key',
+    horizon_ca                   => '/etc/ssl/certs/CA.crt',
+    keystone_multidomain_support => true,
+#   keystone_default_domain      => $ldap_name,
   }
 
   keepalived::vrrp::script { 'check_horizon':

--- a/manifests/openstack/keystone.pp
+++ b/manifests/openstack/keystone.pp
@@ -109,13 +109,17 @@ class profile::openstack::keystone {
     user_allow_update         => False,
     user_allow_delete         => False,
     use_tls                   => False,
-#    identity_driver           => ldap,
     before                    => Anchor['profile::openstack::keystone::end'],
     require                   => Anchor['profile::openstack::keystone::begin'],
   }
  
   keystone_domain_config { 
     "${ldap_name}::identity/driver": value => 'ldap';
+  }
+
+  keystone_domain { $ldap_name:
+    ensure  => present,
+    enabled => true,
   }
 
   keepalived::vrrp::script { 'check_keystone':

--- a/manifests/openstack/keystone.pp
+++ b/manifests/openstack/keystone.pp
@@ -109,10 +109,15 @@ class profile::openstack::keystone {
     user_allow_update         => False,
     user_allow_delete         => False,
     use_tls                   => False,
-    identity_driver           => ldap,
+#    identity_driver           => ldap,
+    before                    => Anchor['profile::openstack::keystone::end'],
+    require                   => Anchor['profile::openstack::keystone::begin'],
   }
  
-  
+  keystone_domain_config { 
+    "${ldap_name}::identity/driver": value => 'ldap';
+  }
+
   keepalived::vrrp::script { 'check_keystone':
     script   => '/usr/bin/killall -0 keystone-all',
     before   => Anchor['profile::openstack::keystone::end'],


### PR DESCRIPTION
Added LDAP support, to allow authentication using the normal NTNU accounts.

A couple of new hiera keys:
 -profile::keystone::ldap_backend::name
 -profile::keystone::ldap_backend::url
 -profile::keystone::ldap_backend::user
 -profile::keystone::ldap_backend::password
 -profile::keystone::ldap_backend::suffix
 -profile::keystone::ldap_backend::user_tree_dn
 -profile::keystone::ldap_backend::user_filter

I addition this merge brings in the installation of the openstack repos to baseconfig. This ensures that all the openstack clients are brought into the correct version.