### PR TITLE
New default values for ceph pools, new default bashrc for root

### DIFF
--- a/files/.bashrc
+++ b/files/.bashrc
@@ -1,0 +1,99 @@
+# ~/.bashrc: executed by bash(1) for non-login shells.
+# see /usr/share/doc/bash/examples/startup-files (in the package bash-doc)
+# for examples
+
+# If not running interactively, don't do anything
+[ -z "$PS1" ] && return
+
+# don't put duplicate lines in the history. See bash(1) for more options
+# ... or force ignoredups and ignorespace
+HISTCONTROL=ignoredups:ignorespace
+
+# append to the history file, don't overwrite it
+shopt -s histappend
+
+# for setting history length see HISTSIZE and HISTFILESIZE in bash(1)
+HISTSIZE=1000
+HISTFILESIZE=2000
+
+# check the window size after each command and, if necessary,
+# update the values of LINES and COLUMNS.
+shopt -s checkwinsize
+
+# make less more friendly for non-text input files, see lesspipe(1)
+[ -x /usr/bin/lesspipe ] && eval "$(SHELL=/bin/sh lesspipe)"
+
+# set variable identifying the chroot you work in (used in the prompt below)
+if [ -z "$debian_chroot" ] && [ -r /etc/debian_chroot ]; then
+    debian_chroot=$(cat /etc/debian_chroot)
+fi
+
+# set a fancy prompt (non-color, unless we know we "want" color)
+case "$TERM" in
+    xterm-color) color_prompt=yes;;
+esac
+
+# uncomment for a colored prompt, if the terminal has the capability; turned
+# off by default to not distract the user: the focus in a terminal window
+# should be on the output of commands, not on the prompt
+#force_color_prompt=yes
+
+if [ -n "$force_color_prompt" ]; then
+    if [ -x /usr/bin/tput ] && tput setaf 1 >&/dev/null; then
+	# We have color support; assume it's compliant with Ecma-48
+	# (ISO/IEC-6429). (Lack of such support is extremely rare, and such
+	# a case would tend to support setf rather than setaf.)
+	color_prompt=yes
+    else
+	color_prompt=
+    fi
+fi
+
+if [ "$color_prompt" = yes ]; then
+    PS1='${debian_chroot:+($debian_chroot)}\[\033[01;32m\]\u@$(hostname -f)\[\033[00m\]:\[\033[01;34m\]\w\[\033[00m\]\$ '
+else
+    PS1='${debian_chroot:+($debian_chroot)}\u@$(hostname -f):\w\$ '
+fi
+unset color_prompt force_color_prompt
+
+# If this is an xterm set the title to user@host:dir
+case "$TERM" in
+xterm*|rxvt*)
+    PS1="\[\e]0;${debian_chroot:+($debian_chroot)}\u@$(hostname -f): \w\a\]$PS1"
+    ;;
+*)
+    ;;
+esac
+
+# enable color support of ls and also add handy aliases
+if [ -x /usr/bin/dircolors ]; then
+    test -r ~/.dircolors && eval "$(dircolors -b ~/.dircolors)" || eval "$(dircolors -b)"
+    alias ls='ls --color=auto'
+    #alias dir='dir --color=auto'
+    #alias vdir='vdir --color=auto'
+
+    alias grep='grep --color=auto'
+    alias fgrep='fgrep --color=auto'
+    alias egrep='egrep --color=auto'
+fi
+
+# some more ls aliases
+alias ll='ls -alF'
+alias la='ls -A'
+alias l='ls -CF'
+
+# Alias definitions.
+# You may want to put all your additions into a separate file like
+# ~/.bash_aliases, instead of adding them here directly.
+# See /usr/share/doc/bash-doc/examples in the bash-doc package.
+
+if [ -f ~/.bash_aliases ]; then
+    . ~/.bash_aliases
+fi
+
+# enable programmable completion features (you don't need to enable
+# this, if it's already enabled in /etc/bash.bashrc and /etc/profile
+# sources /etc/bash.bashrc).
+#if [ -f /etc/bash_completion ] && ! shopt -oq posix; then
+#    . /etc/bash_completion
+#fi

--- a/manifests/openstack/glance.pp
+++ b/manifests/openstack/glance.pp
@@ -33,7 +33,7 @@ class profile::openstack::glance {
     ],
   }
 
-  exec { '/usr/bin/ceph osd pool create images 4096' :
+  exec { '/usr/bin/ceph osd pool create images 128' :
     unless  => '/usr/bin/ceph osd pool get images size',
     before  => Anchor['profile::openstack::glance::end'],
     require => [

--- a/manifests/openstack/novacompute.pp
+++ b/manifests/openstack/novacompute.pp
@@ -39,7 +39,7 @@ class profile::openstack::novacompute {
     rabbit_password     => $rabbit_pass,
   }
 
-  exec { '/usr/bin/ceph osd pool create volumes 4096' :
+  exec { '/usr/bin/ceph osd pool create volumes 512' :
     unless  => '/usr/bin/ceph osd pool get volumes size',
     require => Anchor['profile::ceph::client::end'],
   }

--- a/manifests/users.pp
+++ b/manifests/users.pp
@@ -1,22 +1,32 @@
+# Includes the defined users, and sets various configuration for root-user
 class profile::users {
   group { 'users':
     ensure => present,
-    gid => 700,
+    gid    => 700,
   }
 
-  file { "/root/.ssh":
-    owner    => "root",
-    group    => "root",
-    mode     => 700,
-    ensure   => "directory",
+  file { '/root/.ssh':
+    ensure => 'directory',
+    owner  => 'root',
+    group  => 'root',
+    mode   => '0700',
   }
-  ssh_authorized_key { "root@manager":
-    user => "root",
-    type => 'ssh-rsa',
-    key => 'AAAAB3NzaC1yc2EAAAADAQABAAABAQCdvmiR2cTIKgxSHfIADwb808QDnqx83VxsqNlmRYx3CopAbrXMF/84WAMkYcumnG4y7qIhCbkLfMlaB4Ym1mutmQWWxUVnnLGUsxoeZxPqbeBcmkwSseahEl1X/yg65H0rh+9bj6gCLbNdORM6sqAVlzdHpus3VppVdFr8Wq1Zm37rh4dI2SWfMDrND9RfZ2Eirmg3HhhF+MAiADo4itGbsR7ALJWf0V6kTFr2sgDZ2fNZ8xDO52bS1LxJK9s0zL+ilyi+vhGNCv00yrYe9CQAGG4P2C/sDNyDt6eaEg4c5eCgba1mfjSrFlIZg6ZGaxkJ5IAli71oN+honP7z0XGL',
-    require => File['/root/.ssh'], 
+
+  ssh_authorized_key { 'root@manager':
+    user    => 'root',
+    type    => 'ssh-rsa',
+    key     => 'AAAAB3NzaC1yc2EAAAADAQABAAABAQCdvmiR2cTIKgxSHfIADwb808QDnqx83VxsqNlmRYx3CopAbrXMF/84WAMkYcumnG4y7qIhCbkLfMlaB4Ym1mutmQWWxUVnnLGUsxoeZxPqbeBcmkwSseahEl1X/yg65H0rh+9bj6gCLbNdORM6sqAVlzdHpus3VppVdFr8Wq1Zm37rh4dI2SWfMDrND9RfZ2Eirmg3HhhF+MAiADo4itGbsR7ALJWf0V6kTFr2sgDZ2fNZ8xDO52bS1LxJK9s0zL+ilyi+vhGNCv00yrYe9CQAGG4P2C/sDNyDt6eaEg4c5eCgba1mfjSrFlIZg6ZGaxkJ5IAli71oN+honP7z0XGL',
+    require => File['/root/.ssh'],
   }
-  
+
+  file { '/root/.bashrc':
+    ensure => 'file',
+    owner  => 'root',
+    group  => 'root',
+    mode   => '0644',
+    source => 'puppet:///modules/profile/.bashrc',
+  }
+
   include ::profile::users::eigil
   include ::profile::users::erikh
   include ::profile::users::larserik


### PR DESCRIPTION
Changed the default pg_num values for out ceph pools, so it will be correct in an event of a full reinstall. Also added a default .bashrc file for root, så each server's FQDN will show in the cli prompt.