### PR TITLE
Prepare for IPv6-pd, 14.04/16.04 compitability and ssh-key

### DIFF
--- a/example/hieradata/common.yaml.1controller
+++ b/example/hieradata/common.yaml.1controller
@@ -3,6 +3,8 @@ profile::user::erikh::hash: ''
 profile::user::eigil::hash: ''
 profile::user::larserik::hash: ''
 
+profile::puppet::environment: 'environmentname'
+
 # Host settings
 controller::names:
   - 'controller01'

--- a/example/hieradata/common.yaml.3controller
+++ b/example/hieradata/common.yaml.3controller
@@ -3,6 +3,8 @@ profile::user::erikh::hash: ''
 profile::user::eigil::hash: ''
 profile::user::larserik::hash: ''
 
+profile::puppet::environment: 'environmentname'
+
 # Host settings
 controller::names:
   - 'controller01'

--- a/manifests/baseconfig.pp
+++ b/manifests/baseconfig.pp
@@ -23,21 +23,22 @@ class profile::baseconfig {
   }
 
   package { [
+    'atop',
     'bc',
+    'ethtool',
     'fio',
     'git',
     'gdisk',
     'htop',
+    'iotop',
     'iperf3',
+    'locate',
     'pwgen',
     'qemu-utils',
-    'sysstat',
-    'vim',
-    'ethtool',
-    'iotop',
-    'atop',
     'screen',
-    'locate'
+    'sysstat',
+    'tcpdump',
+    'vim',
   ] :
     ensure => 'present',
   }
@@ -87,6 +88,7 @@ class profile::baseconfig {
       section => 'agent',
       setting => 'environment',
       value   => $environment,
+      notify  => Service['puppet'],
     } ->
     service { 'puppet':
       ensure => 'running',

--- a/manifests/baseconfig.pp
+++ b/manifests/baseconfig.pp
@@ -17,6 +17,7 @@ define setDHCP {
 # This class provides basic configuration of our hosts. Sets up NTP, installs
 # some base utilities, configures networking and so fort.
 class profile::baseconfig {
+  $environment = hiera('profile::puppet::environment')
   if($::bios_vendor == 'HP') {
     include ::hpacucli
   }
@@ -82,6 +83,17 @@ class profile::baseconfig {
       section => '',
       setting => 'START',
       value   => 'yes',
+    } ->
+    # This environment is not the one really used, as that is decided by
+    # foreman's ENC, but puppet gets really sad if this setting points to a
+    # non-existent environment. This setting might also get useful in the cases
+    # where an ENC  is not used.
+    ini_setting { 'Puppet environment':
+      ensure  => present,
+      path    => '/etc/puppet/puppet.conf',
+      section => 'agent',
+      setting => 'environment',
+      value   => $environment,
     } ->
     service { 'puppet':
       ensure => 'running',

--- a/manifests/baseconfig.pp
+++ b/manifests/baseconfig.pp
@@ -52,13 +52,6 @@ class profile::baseconfig {
   #    }
   #}
 
-  include ::keystone::client
-  include ::cinder::client
-  include ::nova::client
-  include ::neutron::client
-  include ::glance::client
-  include ::profile::openstack::repo
-
   class { '::ntp':
     servers  => [ 'ntp.hig.no'],
     restrict => [

--- a/manifests/baseconfig.pp
+++ b/manifests/baseconfig.pp
@@ -61,40 +61,52 @@ class profile::baseconfig {
     ],
   }
 
+  # If we are running on ubuntu 14.04, add the puppet repos to get puppet 3.8.
   if ($::lsbdistcodename == 'trusty') {
     apt::source { 'puppetlabs':
       location   => 'http://apt.puppetlabs.com',
       repos      => 'main',
       key        => '1054B7A24BD6EC30',
       key_server => 'pgp.mit.edu',
-    } ->
-    package { 'puppet':
-      ensure => '3.8.7-1puppetlabs1',
-    } ->
-    ini_setting { 'Puppet Start':
-      ensure  => present,
-      path    => '/etc/default/puppet',
-      section => '',
-      setting => 'START',
-      value   => 'yes',
-    } ->
-    # This environment is not the one really used, as that is decided by
-    # foreman's ENC, but puppet gets really sad if this setting points to a
-    # non-existent environment. This setting might also get useful in the cases
-    # where an ENC  is not used.
-    ini_setting { 'Puppet environment':
-      ensure  => present,
-      path    => '/etc/puppet/puppet.conf',
-      section => 'agent',
-      setting => 'environment',
-      value   => $environment,
-      notify  => Service['puppet'],
-    } ->
-    service { 'puppet':
-      ensure => 'running',
+      before     => Package['puppet'],
     }
   }
+  
+  package { 'puppet':
+    ensure => 'present',
+  }
 
+  ini_setting { 'Puppet Start':
+    ensure  => present,
+    path    => '/etc/default/puppet',
+    section => '',
+    setting => 'START',
+    value   => 'yes',
+    require => Package['puppet'],
+  }
+
+  # This environment is not the one really used, as that is decided by
+  # foreman's ENC, but puppet gets really sad if this setting points to a
+  # non-existent environment. This setting might also get useful in the cases
+  # where an ENC  is not used.
+  ini_setting { 'Puppet environment':
+    ensure  => present,
+    path    => '/etc/puppet/puppet.conf',
+    section => 'agent',
+    setting => 'environment',
+    value   => $environment,
+    notify  => Service['puppet'],
+    require => Package['puppet'],
+  }
+
+  service { 'puppet':
+    ensure  => 'running',
+    require => Package['puppet'],
+  }
+
+  # If the puppet-version is new enough to support ecda ssh-keys (which is
+  # default in openssh these days), configure ssh. If puppet is too old; it
+  # should be updated so that ssh gets configured... :)
   if ($::puppetversion > '3.5.0') {
     class {'::ssh':
       server_options => {
@@ -113,22 +125,17 @@ class profile::baseconfig {
     }
 
     exec {'shosts.equiv':
-      command => 'cat /etc/ssh/ssh_known_hosts | grep -v "^#" | awk \'{print $1}\' | sed -e \'s/,/\n/g\' > /etc/ssh/shosts.equiv',
+      command => 'cat /etc/ssh/ssh_known_hosts | grep -v "^#" | \
+                  awk \'{print $1}\' | sed -e \'s/,/\n/g\' > \
+                  /etc/ssh/shosts.equiv',
       path    => '/bin:/usr/bin',
       require => Class['ssh::knownhosts'],
     }
   }
 
+  # Configure interfaces as instructed in hiera.
   $interfacesToConfigure = hiera('profile::interfaces', false)
   if($interfacesToConfigure) {
     setDHCP { $interfacesToConfigure: }
   }
-
-#  mount{'/fill':
-#    ensure => absent,
-#  } ->
-#  logical_volume { 'fill':
-#    ensure       => absent,
-#    volume_group => 'hdd',
-#  }
 }

--- a/manifests/openstack/clients.pp
+++ b/manifests/openstack/clients.pp
@@ -1,0 +1,10 @@
+# This class installs the openstack clients.
+class profile::openstack::clients {
+  include ::profile::openstack::repo
+
+  include ::keystone::client
+  include ::cinder::client
+  include ::nova::client
+  include ::neutron::client
+  include ::glance::client
+}

--- a/manifests/openstack/horizon.pp
+++ b/manifests/openstack/horizon.pp
@@ -19,6 +19,8 @@ class profile::openstack::horizon {
   $ssl_cert = hiera('profile::horizon::ssl_cert')
   $ssl_ca = hiera('profile::horizon::ssl_ca')
 
+  include ::profile::openstack::repo
+
   anchor { 'profile::openstack::horizon::begin' :
     require => [
       Anchor['profile::mysqlcluster::end'],

--- a/manifests/openstack/neutronserver.pp
+++ b/manifests/openstack/neutronserver.pp
@@ -75,13 +75,9 @@ class profile::openstack::neutronserver {
   neutron_config {
     'DEFAULT/ipv6_pd_enabled': value => 'True';
   }
-
-  # As the dibbler-client is not available in a new enough version for Ubuntu
-  # 14.04, it needs to be manually installed... 
-  #
-  #package { 'dibbler-client':
-  #  ensure => 'latest',
-  #}
+  package { 'dibbler-client':
+    ensure => 'present',
+  }
 
   class { '::neutron::keystone::auth':
     password     => $neutron_password,

--- a/manifests/openstack/neutronserver.pp
+++ b/manifests/openstack/neutronserver.pp
@@ -107,9 +107,9 @@ class profile::openstack::neutronserver {
     database_connection              => $database_connection,
     sync_db                          => true,
     allow_automatic_l3agent_failover => true,
-    l3_ha                            => true,
-    min_l3_agents_per_router         => 2,
-    max_l3_agents_per_router         => 3,
+    #l3_ha                            => true,
+    #min_l3_agents_per_router         => 2,
+    #max_l3_agents_per_router         => 3,
     before                           => Anchor['profile::openstack::neutron::end'],
     require                          => Anchor['profile::openstack::neutron::begin'],
   }

--- a/manifests/users/larserik.pp
+++ b/manifests/users/larserik.pp
@@ -26,4 +26,11 @@ class profile::users::larserik {
     key     => 'AAAAB3NzaC1yc2EAAAADAQABAAACAQCwFrm/iRtOpOrRzd/Sxe8zFOKnScuTqAAONj4IxX+D59fg+53kOTYI8Gn6Q54dUb8aurS8as92LH2Y8quzrGSt8ZP8pT8JxuDyhWlPcFGo82krdCkZPLK5wRhwYAsNSUVrQJcb2e0kNAR0/wBkQxd70WbW4uCJlzQr9v/9SJEnUr+Gv9ImBbcOF2zpo1+b2Sy3syOMOnnPdNi9HZy0OktyMl2vo2+tjavUSqv7khI3RktYdWbV/TZ/sCuRh26KPtMzIL3sjCEOIm9i3UY5KBBLZpOMZEE5Tq6BVVrE1I8lZKoLBm4s9OI8kEGYDP+7FREigqozr8yUWy+dZisH6YhG4Uk6KKhhoyuii/MC6o0BpaW++0JkUeUvadpzNie4DlLIduJSNWJMiuHvvkmO8HUWZs/KDUUzmDzPBbjQStiT8AAXdrluRR80yI1U9qSAdbhu5I36t+z+5F2F9OBArpbIAoogRQDah9VMCVdCQLkw0G07wzgLbUWEYiKKSLyDkyeZArXRXAqxbi8BOX3lqPhtqcAGroSPJlN74lR5TFTz3RDZWWaYzYeWWeg8jgAHNQYuAx0EtFdLnPHe2p6eLQXWEcZPpTPQD7VepS6IssigEpZ8pqlq2Eax2lvuOYdqigSXC6YxF+dhLZ8BhhwUUkGtW00D6ubaFWxgvr/N3A9nCQ==',
     require => File['/home/larserik/.ssh'],
   }
+
+  ssh_authorized_key { 'larserik@manager':
+    user    => 'larserik',
+    type    => 'ssh-rsa',
+    key     => 'AAAAB3NzaC1yc2EAAAADAQABAAACAQDTy2a7heSEkJBJytlwEVq9wcwYdCmfQJFZT+VLS03g/4sfomc3cFvR8SREhtnP3dMWTqvcACb4upuUEMo+ym1gzWU66gr3xvnvpUmK0gqWLPvx4zOijV3x1cY9pgmV/uRXfnUhkUeD41VE+c7r+sS/uZk81IBi1UmWN34gY8PjZUFKTkHhH5UaXWvkuF8d3jz70EBhEPOLHldmbxsx++EuYoletsbRJ1AGFkJcG+TFL0SvXHP1JEZVtd6vR0zJEE/hzNIUCGnpHoEeIiR4XTLv/WlNN5KxSguOF6T8HKVWWrccQAweQZ29xTYkpo+3wu/Ffaetv1/paCS+8ncYU0cE4oIxjMT+WgpiOSV60btpNOolPmUUeSDNDpCWyk8awVCHY74eYhjTK/7/HZ4T1lLzyWmH8wVCeVE+cKpN2KnKifG1i3zaRIvCMuCwK6bFBzB1iwNEYp0PDRpfEmN71TmxdAyw8EzsrIQ3WiKY2dCZOB9VPyt9FvMJkurHxWrKr93FjAoTlzYI9apOYs41XZVLSN06mOCpEOrXgwedOO5RxoyRxexV9vmzxPKf098OzAQ/Uq6ZC/YzOtW37K7ShguifooB/qRm+fF6JTIKtS1ng6mtFvYGJAqBxvH3OXbXI5J4tk9XqQpP46gI4g/Y8cADNEPIh6zmsMBhncgcLGWm0w==',
+    require => File['/home/larserik/.ssh'],
+  }
 }


### PR DESCRIPTION
This merge pulls in the following changes:
- Installs and configured needed settings for IPv6-pd delegation
- Ensures that puppet grabs its default environment (the one configured in puppet.conf) from hiera
- Moving openstack-clients away from baseconfig, so that we can have nodes without the openstack repos.
- A new ssh-key to lars erik.
- Updated baseconfig to alway configuring puppet.