### PR TITLE
Fwaas

### DIFF
--- a/example/hieradata/openstack.yaml
+++ b/example/hieradata/openstack.yaml
@@ -44,6 +44,10 @@ profile::nova::dns: '129.241.0.200,129.241.0.201'
 profile::neutron::keystone::password: '<pwgen>'
 profile::neutron::service_plugins:
   - 'router'
+  - 'firewall'
+profile::neutron::service_providers:
+ - 'FIREWALL:Iptables:neutron.agent.linux.iptables_firewall.OVSHybridIptablesFirewallDriver:default'
+profile::neutron::fwaas_driver: 'neutron_fwaas.services.firewall.drivers.linux.iptables_fwaas.IptablesFwaasDriver'
 profile::neutron::vrrp_pass: '<pwgen>'
 profile::neutron::vlan_low: <VLAN-ID>
 profile::neutron::vlan_high: <VLAN-ID>

--- a/manifests/baseconfig/puppet.pp
+++ b/manifests/baseconfig/puppet.pp
@@ -1,6 +1,7 @@
 # This class installs and configures puppet.
 class profile::baseconfig::puppet {
   $environment = hiera('profile::puppet::environment')
+  $configtimeout = hiera('profile:puppet::configtimeout', '3m')
 
   # If we are running on ubuntu 14.04, add the puppet repos to get puppet 3.8.
   if ($::lsbdistcodename == 'trusty') {
@@ -12,7 +13,7 @@ class profile::baseconfig::puppet {
       before     => Package['puppet'],
     }
   }
-  
+
   package { 'puppet':
     ensure => 'present',
   }
@@ -37,6 +38,16 @@ class profile::baseconfig::puppet {
     setting => 'environment',
     value   => $environment,
     notify  => Service['puppet'],
+    require => Package['puppet'],
+  }
+
+  # This is to avoid ENC timeouts on nodes with hilarious amounts of facts...
+  ini_setting { 'Puppet configtimeout':
+    ensure  => 'present',
+    path    => '/etc/puppet/puppet.conf',
+    section => 'agent',
+    setting => 'configtimeout',
+    value   => $configtimeout,
     require => Package['puppet'],
   }
 

--- a/manifests/openstack/horizon.pp
+++ b/manifests/openstack/horizon.pp
@@ -61,6 +61,9 @@ class profile::openstack::horizon {
     horizon_ca                   => '/etc/ssl/certs/CA.crt',
     keystone_multidomain_support => true,
 #   keystone_default_domain      => $ldap_name,
+    neutron_options              => {
+      enable_firewall => true,
+    },
   }
 
   keepalived::vrrp::script { 'check_horizon':

--- a/manifests/openstack/neutronagent.pp
+++ b/manifests/openstack/neutronagent.pp
@@ -78,7 +78,7 @@ class profile::openstack::neutronagent {
   }
 
   neutron_l3_agent_config {
-    'AGENT/extensions': value => 'fwaas_v2';
+    'AGENT/extensions': value => 'fwaas';
   }
 
   sudo::conf { 'neutron_sudoers':

--- a/manifests/openstack/neutronagent.pp
+++ b/manifests/openstack/neutronagent.pp
@@ -77,6 +77,10 @@ class profile::openstack::neutronagent {
     require             => Anchor['profile::openstack::neutronagent::begin'],
   }
 
+  neutron_l3_agent_config {
+    'AGENT/extensions': value => 'fwaas';
+  }
+
   sudo::conf { 'neutron_sudoers':
     ensure         => 'present',
     source         => 'puppet:///modules/profile/sudo/neutron_sudoers',

--- a/manifests/openstack/neutronagent.pp
+++ b/manifests/openstack/neutronagent.pp
@@ -78,7 +78,7 @@ class profile::openstack::neutronagent {
   }
 
   neutron_l3_agent_config {
-    'AGENT/extensions': value => 'fwaas';
+    'AGENT/extensions': value => 'fwaas_v2';
   }
 
   sudo::conf { 'neutron_sudoers':

--- a/manifests/openstack/neutronserver.pp
+++ b/manifests/openstack/neutronserver.pp
@@ -19,6 +19,7 @@ class profile::openstack::neutronserver {
   $nova_admin_ip = hiera('profile::api::nova::admin::ip')
   $nova_public_ip = hiera('profile::api::nova::public::ip')
   $service_plugins = hiera('profile::neutron::service_plugins')
+  $service_providers = hiera('profile::neutron::service_providers')
   $neutron_vrrp_pass = hiera('profile::neutron::vrrp_pass')
   $nova_metadata_secret = hiera('profile::nova::sharedmetadataproxysecret')
   $dns_servers = hiera('profile::nova::dns')
@@ -38,7 +39,6 @@ class profile::openstack::neutronserver {
   $memcached_ip = hiera('profile::memcache::ip')
 
   $database_connection = "mysql://neutron:${password}@${mysql_ip}/neutron"
-  $fw_provider = 'FIREWALL:Iptables:neutron.agent.linux.iptables_firewall.OVSHybridIptablesFirewallDriver:default'
   $fw_driver = 'neutron_fwaas.services.firewall.drivers.linux.iptables_fwaas_v2.IptablesFwaasDriver'
 
   require ::profile::mysql::cluster
@@ -101,6 +101,8 @@ class profile::openstack::neutronserver {
     database_connection              => $database_connection,
     sync_db                          => true,
     allow_automatic_l3agent_failover => true,
+    service_providers                => $service_providers,
+    ensure_fwaas_package             => true,
   }
 
   class { '::neutron::agents::dhcp':
@@ -140,7 +142,6 @@ class profile::openstack::neutronserver {
   }
 
   neutron_config {
-    'service_providers/service_provider': value => $fw_provider;
     'fwaas/agent_version':                value => 'v2';
     'fwaas/driver' :                      value => 'iptables';
     'fwaas/enabled':                      value => 'True';

--- a/manifests/openstack/neutronserver.pp
+++ b/manifests/openstack/neutronserver.pp
@@ -19,7 +19,7 @@ class profile::openstack::neutronserver {
   $nova_admin_ip = hiera('profile::api::nova::admin::ip')
   $nova_public_ip = hiera('profile::api::nova::public::ip')
   $service_plugins = hiera('profile::neutron::service_plugins')
-  #  $service_providers = hiera('profile::neutron::service_providers')
+  $service_providers = hiera('profile::neutron::service_providers')
   $neutron_vrrp_pass = hiera('profile::neutron::vrrp_pass')
   $nova_metadata_secret = hiera('profile::nova::sharedmetadataproxysecret')
   $dns_servers = hiera('profile::nova::dns')

--- a/manifests/openstack/neutronserver.pp
+++ b/manifests/openstack/neutronserver.pp
@@ -102,7 +102,6 @@ class profile::openstack::neutronserver {
     sync_db                          => true,
     allow_automatic_l3agent_failover => true,
     service_providers                => $service_providers,
-    ensure_fwaas_package             => true,
   }
 
   class { '::neutron::agents::dhcp':

--- a/manifests/openstack/neutronserver.pp
+++ b/manifests/openstack/neutronserver.pp
@@ -39,7 +39,8 @@ class profile::openstack::neutronserver {
   $memcached_ip = hiera('profile::memcache::ip')
 
   $database_connection = "mysql://neutron:${password}@${mysql_ip}/neutron"
-  $fw_driver = 'neutron_fwaas.services.firewall.drivers.linux.iptables_fwaas_v2.IptablesFwaasDriver'
+  #$fw_driver = 'neutron_fwaas.services.firewall.drivers.linux.iptables_fwaas_v2.IptablesFwaasDriver'
+  $fw_driver = 'iptables'
 
   require ::profile::mysql::cluster
   require ::profile::services::keepalived
@@ -141,13 +142,13 @@ class profile::openstack::neutronserver {
   }
 
   neutron_config {
-    'fwaas/agent_version':                value => 'v2';
-    'fwaas/driver' :                      value => 'iptables';
-    'fwaas/enabled':                      value => 'True';
+    'fwaas/agent_version': value => 'v2';
+    'fwaas/driver' :       value => 'iptables';
+    'fwaas/enabled':       value => 'True';
   }
 
   neutron_l3_agent_config {
-    'AGENT/extensions': value => 'fwaas';
+    'AGENT/extensions': value => 'fwaas_v2';
   }
 
   vs_port { $external_if:

--- a/manifests/openstack/neutronserver.pp
+++ b/manifests/openstack/neutronserver.pp
@@ -141,10 +141,8 @@ class profile::openstack::neutronserver {
     driver  => $fw_driver,
   }
 
-  neutron_config {
+  neutron_fwaas_service_config {
     'fwaas/agent_version': value => 'v2';
-    'fwaas/driver' :       value => $fw_driver;
-    'fwaas/enabled':       value => 'True';
   }
 
   neutron_l3_agent_config {

--- a/manifests/openstack/neutronserver.pp
+++ b/manifests/openstack/neutronserver.pp
@@ -19,7 +19,7 @@ class profile::openstack::neutronserver {
   $nova_admin_ip = hiera('profile::api::nova::admin::ip')
   $nova_public_ip = hiera('profile::api::nova::public::ip')
   $service_plugins = hiera('profile::neutron::service_plugins')
-  $service_providers = hiera('profile::neutron::service_providers')
+  #  $service_providers = hiera('profile::neutron::service_providers')
   $neutron_vrrp_pass = hiera('profile::neutron::vrrp_pass')
   $nova_metadata_secret = hiera('profile::nova::sharedmetadataproxysecret')
   $dns_servers = hiera('profile::nova::dns')

--- a/manifests/openstack/neutronserver.pp
+++ b/manifests/openstack/neutronserver.pp
@@ -40,7 +40,7 @@ class profile::openstack::neutronserver {
 
   $database_connection = "mysql://neutron:${password}@${mysql_ip}/neutron"
   #$fw_driver = 'neutron_fwaas.services.firewall.drivers.linux.iptables_fwaas_v2.IptablesFwaasDriver'
-  $fw_driver = 'iptables'
+  $fw_driver = 'iptables_v2'
 
   require ::profile::mysql::cluster
   require ::profile::services::keepalived
@@ -143,7 +143,7 @@ class profile::openstack::neutronserver {
 
   neutron_config {
     'fwaas/agent_version': value => 'v2';
-    'fwaas/driver' :       value => 'iptables';
+    'fwaas/driver' :       value => $fw_driver;
     'fwaas/enabled':       value => 'True';
   }
 

--- a/manifests/openstack/neutronserver.pp
+++ b/manifests/openstack/neutronserver.pp
@@ -39,8 +39,8 @@ class profile::openstack::neutronserver {
   $memcached_ip = hiera('profile::memcache::ip')
 
   $database_connection = "mysql://neutron:${password}@${mysql_ip}/neutron"
-  #$fw_driver = 'neutron_fwaas.services.firewall.drivers.linux.iptables_fwaas_v2.IptablesFwaasDriver'
-  $fw_driver = 'iptables_v2'
+  $fw_driver = 'neutron_fwaas.services.firewall.drivers.linux.iptables_fwaas.IptablesFwaasDriver'
+  #$fw_driver = 'iptables_v2'
 
   require ::profile::mysql::cluster
   require ::profile::services::keepalived
@@ -142,11 +142,11 @@ class profile::openstack::neutronserver {
   }
 
   neutron_fwaas_service_config {
-    'fwaas/agent_version': value => 'v2';
+    'fwaas/agent_version': value => 'v1';
   }
 
   neutron_l3_agent_config {
-    'AGENT/extensions': value => 'fwaas_v2';
+    'AGENT/extensions': value => 'fwaas';
   }
 
   vs_port { $external_if:

--- a/manifests/openstack/neutronserver.pp
+++ b/manifests/openstack/neutronserver.pp
@@ -20,6 +20,7 @@ class profile::openstack::neutronserver {
   $nova_public_ip = hiera('profile::api::nova::public::ip')
   $service_plugins = hiera('profile::neutron::service_plugins')
   $service_providers = hiera('profile::neutron::service_providers')
+  $fw_driver = hiera('profile::neutron::fwaas_driver')
   $neutron_vrrp_pass = hiera('profile::neutron::vrrp_pass')
   $nova_metadata_secret = hiera('profile::nova::sharedmetadataproxysecret')
   $dns_servers = hiera('profile::nova::dns')
@@ -39,8 +40,6 @@ class profile::openstack::neutronserver {
   $memcached_ip = hiera('profile::memcache::ip')
 
   $database_connection = "mysql://neutron:${password}@${mysql_ip}/neutron"
-  $fw_driver = 'neutron_fwaas.services.firewall.drivers.linux.iptables_fwaas.IptablesFwaasDriver'
-  #$fw_driver = 'iptables_v2'
 
   require ::profile::mysql::cluster
   require ::profile::services::keepalived


### PR DESCRIPTION
Enabling FWaaS V1 in Neutron
Depends on some new hiera keys:

```
profile::neutron::service_plugins:
 - 'router'
 - 'firewall'
profile::neutron::service_providers:
 - 'FIREWALL:Iptables:neutron.agent.linux.iptables_firewall.OVSHybridIptablesFirewallDriver:default'
profile::neutron::fwaas_driver: 'neutron_fwaas.services.firewall.drivers.linux.iptables_fwaas.IptablesFwaasDriver'
```