### PR TITLE
Optionalv6

### DIFF
--- a/manifests/baseconfig/configureinterface.pp
+++ b/manifests/baseconfig/configureinterface.pp
@@ -4,7 +4,7 @@ define profile::baseconfig::configureinterface {
   $method = hiera("profile::interfaces::${name}::method")
   $v4gateway = hiera("profile::interfaces::${name}::gateway", undef)
   $v6gateway = hiera("profile::interfaces::${name}::gateway6", 'fe80::1')
-  $mtu = hiera("profile::interfaces::${name}::mty", 1500)
+  $mtu = hiera("profile::interfaces::${name}::mtu", 1500)
 
   $dns_servers = hiera('profile::dns::nameservers', undef)
   $dns_search = hiera('profile::dns::searchdomain', undef)

--- a/manifests/baseconfig/configureinterface.pp
+++ b/manifests/baseconfig/configureinterface.pp
@@ -5,18 +5,25 @@ define profile::baseconfig::configureinterface {
   $v4gateway = hiera("profile::interfaces::${name}::gateway", undef)
   $v6gateway = hiera("profile::interfaces::${name}::gateway6", 'fe80::1')
 
+  $dns_servers = hiera('profile::dns::nameservers', undef)
+  $dns_search = hiera('profile::dns::searchdomain', undef)
+
   if($method == 'dhcp') {
     network::interface { $name:
-      enable_dhcp => true,
+      enable_dhcp     => true,
+      dns_nameservers => $dns_servers,
+      dns_search      => $dns_search,
     }
   } else {
     $address = hiera("profile::interfaces::${name}::address", undef)
     $netmask = hiera("profile::interfaces::${name}::netmask", undef)
     network::interface{ $name:
-      method    => $method,
-      ipaddress => $address,
-      netmask   => $netmask,
-      gateway   => $v4gateway,
+      method          => $method,
+      ipaddress       => $address,
+      netmask         => $netmask,
+      gateway         => $v4gateway,
+      dns_nameservers => $dns_servers,
+      dns_search      => $dns_search,
     }
   }
 

--- a/manifests/baseconfig/configureinterface.pp
+++ b/manifests/baseconfig/configureinterface.pp
@@ -4,7 +4,7 @@ define profile::baseconfig::configureinterface {
   $method = hiera("profile::interfaces::${name}::method")
   $v4gateway = hiera("profile::interfaces::${name}::gateway", undef)
   $v6gateway = hiera("profile::interfaces::${name}::gateway6", 'fe80::1')
-  $mtu = hiera("profile::interfaces::${name}::mtu", 1500)
+  $mtu = hiera("profile::interfaces::${name}::mtu", undef)
 
   $dns_servers = hiera('profile::dns::nameservers', undef)
   $dns_search = hiera('profile::dns::searchdomain', undef)

--- a/manifests/baseconfig/configureinterface.pp
+++ b/manifests/baseconfig/configureinterface.pp
@@ -17,6 +17,14 @@ define profile::baseconfig::configureinterface {
   } else {
     $address = hiera("profile::interfaces::${name}::address", undef)
     $netmask = hiera("profile::interfaces::${name}::netmask", undef)
+    $primary = hiera("profile::interfaces::${name}::primary", false)
+
+    if($primary) {
+      $gateway_real = $v4gateway
+    } else {
+      $gateway_real = undef
+    }
+
     network::interface{ $name:
       method          => $method,
       ipaddress       => $address,

--- a/manifests/baseconfig/configureinterface.pp
+++ b/manifests/baseconfig/configureinterface.pp
@@ -11,9 +11,7 @@ define profile::baseconfig::configureinterface {
 
   if($method == 'dhcp') {
     network::interface { $name:
-      enable_dhcp     => true,
-      dns_nameservers => $dns_servers,
-      dns_search      => $dns_search,
+      enable_dhcp => true,
     }
   } else {
     $address = hiera("profile::interfaces::${name}::address", undef)

--- a/manifests/baseconfig/configureinterface.pp
+++ b/manifests/baseconfig/configureinterface.pp
@@ -4,6 +4,7 @@ define profile::baseconfig::configureinterface {
   $method = hiera("profile::interfaces::${name}::method")
   $v4gateway = hiera("profile::interfaces::${name}::gateway", undef)
   $v6gateway = hiera("profile::interfaces::${name}::gateway6", 'fe80::1')
+  $mtu = hiera("profile::interfaces::${name}::mty", 1500)
 
   $dns_servers = hiera('profile::dns::nameservers', undef)
   $dns_search = hiera('profile::dns::searchdomain', undef)
@@ -29,9 +30,10 @@ define profile::baseconfig::configureinterface {
       method          => $method,
       ipaddress       => $address,
       netmask         => $netmask,
-      gateway         => $v4gateway,
+      gateway         => $gateway_real,
       dns_nameservers => $dns_servers,
       dns_search      => $dns_search,
+      mtu             => $mtu,
     }
   }
 
@@ -103,15 +105,15 @@ define profile::baseconfig::configureinterface {
 
     network::routing_table { "table-${name}":
       table_id => $table_id,
-    }->
-    network::route { $name:
+    }
+    -> network::route { $name:
       ipaddress => concat($v4netids, $v6netids, $extranetids),
       netmask   => concat($v4masks, $v6masks, $extramasks),
       gateway   => concat($v4gateways, $v6gateways, $extragws),
       table     => concat($v4tables, $v6tables, $extratables),
       family    => concat($v4families, $v6families, $extrafamilies),
-    }->
-    profile::baseconfig::networkrule { $name:
+    }
+    -> profile::baseconfig::networkrule { $name:
       iprule => concat($v4rules, $v6rules),
       family => concat($v4rulef, $v6rulef),
     }

--- a/manifests/monitoring/munin/node/firewall.pp
+++ b/manifests/monitoring/munin/node/firewall.pp
@@ -1,9 +1,9 @@
 # This class opens the firewall for the munin-node
 class profile::monitoring::munin::node::firewall {
   $management_netv4 = hiera('profile::networks::management::ipv4::prefix')
-  $management_netv6 = hiera('profile::networks::management::ipv6::prefix')
+  $management_netv6 = hiera('profile::networks::management::ipv6::prefix', false)
 
-  require ::profile::baseconfig::firewall 
+  require ::profile::baseconfig::firewall
 
   firewall { '050 accept incoming Munin':
     proto  => 'tcp',
@@ -11,11 +11,14 @@ class profile::monitoring::munin::node::firewall {
     action => 'accept',
     source => $management_netv4,
   }
-  firewall { '050 v6accept incoming Munin':
-    proto    => 'tcp',
-    dport    => [4949],
-    action   => 'accept',
-    provider => 'ip6tables',
-    source   => $management_netv6,
+
+  if($management_netv6) {
+    firewall { '050 v6accept incoming Munin':
+      proto    => 'tcp',
+      dport    => [4949],
+      action   => 'accept',
+      provider => 'ip6tables',
+      source   => $management_netv6,
+    }
   }
 }

--- a/manifests/services/haproxy.pp
+++ b/manifests/services/haproxy.pp
@@ -6,7 +6,6 @@ class profile::services::haproxy {
 
   $nic = hiera('profile::interfaces::management')
   $ip = $::facts['networking']['interfaces'][$nic]['ip']
-  $ipv6_management_nets = hiera_array('profile::networking::management::ipv6::prefixes', [])
   $installsensu = hiera('profile::sensu::install', true)
   $sslciphers = "\
 ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:\

--- a/manifests/services/haproxy.pp
+++ b/manifests/services/haproxy.pp
@@ -6,7 +6,7 @@ class profile::services::haproxy {
 
   $nic = hiera('profile::interfaces::management')
   $ip = $::facts['networking']['interfaces'][$nic]['ip']
-  $ipv6_management_nets = hiera_array('profile::networking::management::ipv6::prefixes')
+  $ipv6_management_nets = hiera_array('profile::networking::management::ipv6::prefixes', [])
   $installsensu = hiera('profile::sensu::install', true)
   $sslciphers = "\
 ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:\

--- a/manifests/services/haproxy.pp
+++ b/manifests/services/haproxy.pp
@@ -48,16 +48,40 @@ ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256"
     },
   }
 
-  firewall { '060 accept haproxy stats':
-    proto  => 'tcp',
-    dport  => 9000,
-    action => 'accept',
+  $ipv4_management_nets = hiera_array('profile::networking::management::ipv4::prefixes', false)
+  $ipv6_management_nets = hiera_array('profile::networking::management::ipv6::prefixes', false)
+
+  if($ipv4_management_nets) {
+    $ipv4_management_nets.each |$net| {
+      firewall { "060 accept haproxy stats from ${net}":
+        proto  => 'tcp',
+        dport  => 9000,
+        source => $net,
+        action => 'accept',
+      }
+    }
+  } else {
+    firewall { '060 accept haproxy stats':
+      proto  => 'tcp',
+      dport  => 9000,
+      action => 'accept',
+    }
   }
-  $ipv6_management_nets.each |$net| {
-    firewall { "061 ipv6 accept incoming haproxy stats from ${net}":
+
+  if($ipv6_management_nets) {
+    $ipv6_management_nets.each |$net| {
+      firewall { "061 ipv6 accept incoming haproxy stats from ${net}":
+        proto    => 'tcp',
+        dport    => 9000,
+        source   => $net,
+        action   => 'accept',
+        provider => 'ip6tables',
+      }
+    }
+  } else {
+    firewall { '060 ipv6 accept haproxy stats':
       proto    => 'tcp',
       dport    => 9000,
-      source   => $net,
       action   => 'accept',
       provider => 'ip6tables',
     }

--- a/manifests/services/keepalived/haproxy/management.pp
+++ b/manifests/services/keepalived/haproxy/management.pp
@@ -5,9 +5,9 @@ class profile::services::keepalived::haproxy::management {
   $v4_ip = hiera('profile::haproxy::management::ipv4')
   $v4_id = hiera('profile::haproxy::management::ipv4::id')
   $v4_priority = hiera('profile::haproxy::management::ipv4::priority')
-  $v6_ip = hiera('profile::haproxy::management::ipv6')
-  $v6_id = hiera('profile::haproxy::management::ipv6::id')
-  $v6_priority = hiera('profile::haproxy::management::ipv6::priority')
+  $v6_ip = hiera('profile::haproxy::management::ipv6', false)
+  $v6_id = hiera('profile::haproxy::management::ipv6::id', false)
+  $v6_priority = hiera('profile::haproxy::management::ipv6::priority', false)
 
   $vrrp_password = hiera('profile::keepalived::vrrp_password')
   $management_if = hiera('profile::interfaces::management')
@@ -27,14 +27,16 @@ class profile::services::keepalived::haproxy::management {
     track_script      => 'check_haproxy',
   }
 
-  keepalived::vrrp::instance { 'management-haproxy-v6':
-    interface         => $management_if,
-    state             => 'BACKUP',
-    virtual_router_id => $v6_id,
-    priority          => $v6_priority,
-    auth_type         => 'PASS',
-    auth_pass         => $vrrp_password,
-    virtual_ipaddress => ["${v6_ip}/64"],
-    track_script      => 'check_haproxy',
+  if ( $v6_ip ) {
+    keepalived::vrrp::instance { 'management-haproxy-v6':
+      interface         => $management_if,
+      state             => 'BACKUP',
+      virtual_router_id => $v6_id,
+      priority          => $v6_priority,
+      auth_type         => 'PASS',
+      auth_pass         => $vrrp_password,
+      virtual_ipaddress => ["${v6_ip}/64"],
+      track_script      => 'check_haproxy',
+    } 
   }
 }

--- a/manifests/services/keepalived/haproxy/services.pp
+++ b/manifests/services/keepalived/haproxy/services.pp
@@ -5,9 +5,9 @@ class profile::services::keepalived::haproxy::services {
   $v4_ip = hiera('profile::haproxy::services::ipv4')
   $v4_id = hiera('profile::haproxy::services::ipv4::id')
   $v4_priority = hiera('profile::haproxy::services::ipv4::priority')
-  $v6_ip = hiera('profile::haproxy::services::ipv6')
-  $v6_id = hiera('profile::haproxy::services::ipv6::id')
-  $v6_priority = hiera('profile::haproxy::services::ipv6::priority')
+  $v6_ip = hiera('profile::haproxy::services::ipv6', false)
+  $v6_id = hiera('profile::haproxy::services::ipv6::id', false)
+  $v6_priority = hiera('profile::haproxy::services::ipv6::priority', false)
 
   $vrrp_password = hiera('profile::keepalived::vrrp_password')
   $services_if = hiera('profile::interfaces::services')
@@ -27,14 +27,16 @@ class profile::services::keepalived::haproxy::services {
     track_script      => 'check_haproxy',
   }
 
-  keepalived::vrrp::instance { 'services-haproxy-v6':
-    interface         => $services_if,
-    state             => 'BACKUP',
-    virtual_router_id => $v6_id,
-    priority          => $v6_priority,
-    auth_type         => 'PASS',
-    auth_pass         => $vrrp_password,
-    virtual_ipaddress => ["${v6_ip}/64"],
-    track_script      => 'check_haproxy',
+  if ( $v6_ip ) {
+    keepalived::vrrp::instance { 'services-haproxy-v6':
+      interface         => $services_if,
+      state             => 'BACKUP',
+      virtual_router_id => $v6_id,
+      priority          => $v6_priority,
+      auth_type         => 'PASS',
+      auth_pass         => $vrrp_password,
+      virtual_ipaddress => ["${v6_ip}/64"],
+      track_script      => 'check_haproxy',
+    }
   }
 }

--- a/manifests/services/memcache.pp
+++ b/manifests/services/memcache.pp
@@ -2,7 +2,7 @@
 class profile::services::memcache {
   # Variables for keepalived
   $management_if = hiera('profile::interfaces::management')
-  $memcached_port = '11211'
+  $memcached_port = hiera('profile::memcache::port', '11211')
   $installsensu = hiera('profile::sensu::install', true)
   $installmunin = hiera('profile::munin::install', true)
   $use_keepalived = hiera('profile::memcache::keepalived', false)

--- a/manifests/services/memcache/firewall.pp
+++ b/manifests/services/memcache/firewall.pp
@@ -3,46 +3,24 @@ class profile::services::memcache::firewall {
   require ::profile::baseconfig::firewall
 
   $management_if = hiera('profile::interfaces::management')
-  $sourcev4 = hiera('profile::networks::management::ipv4::prefix')
-  $sourcev4_extra = hiera('profile::networks::management::ipv4::prefix::extra', 
-      false)
-  $sourcev6 = hiera('profile::networks::management::ipv6::prefix')
-  $memcached_port = '11211'
-  $use_keepalived = hiera('profile::memcache::keepalived', false)
+  $memcached_port = hiera('profile::memcache::port', '11211')
 
-  if ( $use_keepalived ) {
-    $destv4 = hiera('profile::memcache::ip')
-  } else {
+  $sourcev4 = hiera('profile::networks::management::ipv4::prefix', false)
+  $sourcev6 = hiera('profile::networks::management::ipv6::prefix', false)
+
+  if ( $sourcev4 ) {
     $destv4 = $::facts['networking']['interfaces'][$management_if]['ip']
-  }
 
-  firewall { '500 accept incoming memcached tcp':
-    source      => $sourcev4,
-    destination => $destv4,
-    proto       => 'tcp',
-    dport       => $memcached_port,
-    action      => 'accept',
-  }
-
-  firewall { '500 accept incoming memcached udp':
-    source      => $sourcev4,
-    destination => $destv4,
-    proto       => 'udp',
-    dport       => $memcached_port,
-    action      => 'accept',
-  }
-
-  if($sourcev4_extra) {
-    firewall { '500 accept incoming memcached tcp from old management':
-      source      => $sourcev4_extra,
+    firewall { '500 accept incoming memcached tcp':
+      source      => $sourcev4,
       destination => $destv4,
       proto       => 'tcp',
       dport       => $memcached_port,
       action      => 'accept',
     }
 
-    firewall { '500 accept incoming memcached udp from old management':
-      source      => $sourcev4_extra,
+    firewall { '500 accept incoming memcached udp':
+      source      => $sourcev4,
       destination => $destv4,
       proto       => 'udp',
       dport       => $memcached_port,
@@ -50,8 +28,9 @@ class profile::services::memcache::firewall {
     }
   }
 
-  if ( ! $use_keepalived ) {
+  if ( ! $sourcev6 ) {
     $destv6 = $::facts['networking']['interfaces'][$management_if]['ip6']
+
     firewall { '500 accept ipv6 incoming memcached tcp':
       source      => $sourcev6,
       destination => $destv6,

--- a/manifests/services/memcache/firewall.pp
+++ b/manifests/services/memcache/firewall.pp
@@ -28,7 +28,7 @@ class profile::services::memcache::firewall {
     }
   }
 
-  if ( ! $sourcev6 ) {
+  if ( $sourcev6 ) {
     $destv6 = $::facts['networking']['interfaces'][$management_if]['ip6']
 
     firewall { '500 accept ipv6 incoming memcached tcp':

--- a/manifests/services/mysql/firewall/balancer.pp
+++ b/manifests/services/mysql/firewall/balancer.pp
@@ -14,7 +14,7 @@ class profile::services::mysql::firewall::balancer {
     }
   }
 
-  if($managementv4) {
+  if($managementv6) {
     firewall { '071 ipv6 Accept incoming MySQL requests':
       source   => $managementv6,
       proto    => 'tcp',

--- a/manifests/services/mysql/firewall/balancer.pp
+++ b/manifests/services/mysql/firewall/balancer.pp
@@ -2,7 +2,7 @@
 class profile::services::mysql::firewall::balancer {
   require ::firewall
 
-  $managementv4 = hiera('profile::networks::management::ipv6::prefix', false)
+  $managementv4 = hiera('profile::networks::management::ipv4::prefix', false)
   $managementv6 = hiera('profile::networks::management::ipv6::prefix', false)
 
   if($managementv4) {

--- a/manifests/services/mysql/firewall/balancer.pp
+++ b/manifests/services/mysql/firewall/balancer.pp
@@ -2,15 +2,25 @@
 class profile::services::mysql::firewall::balancer {
   require ::firewall
 
-  firewall { '071 Accept incoming MySQL requests':
-    proto  => 'tcp',
-    dport  => 3306,
-    action => 'accept',
+  $managementv4 = hiera('profile::networks::management::ipv6::prefix', false)
+  $managementv6 = hiera('profile::networks::management::ipv6::prefix', false)
+
+  if($managementv4) {
+    firewall { '071 Accept incoming MySQL requests':
+      source => $managementv4,
+      proto  => 'tcp',
+      dport  => 3306,
+      action => 'accept',
+    }
   }
-  firewall { '071 ipv6 Accept incoming MySQL requests':
-    proto    => 'tcp',
-    dport    => 3306,
-    action   => 'accept',
-    provider => 'ip6tables', 
+
+  if($managementv4) {
+    firewall { '071 ipv6 Accept incoming MySQL requests':
+      source   => $managementv6,
+      proto    => 'tcp',
+      dport    => 3306,
+      action   => 'accept',
+      provider => 'ip6tables', 
+    }
   }
 }

--- a/manifests/services/postgresql/firewall.pp
+++ b/manifests/services/postgresql/firewall.pp
@@ -3,11 +3,11 @@ class profile::services::postgresql::firewall {
   require ::firewall
 
   $management_net = hiera('profile::networks::management::ipv4::prefix')
-  $management_netv6 = hiera('profile::networks::management::ipv6::prefix')
+  $management_netv6 = hiera('profile::networks::management::ipv6::prefix', false)
   $management_if = hiera('profile::interfaces::management')
   $ip = $facts['networking']['interfaces'][$management_if]['ip']
   $postgresql_ipv4 = hiera('profile::postgres::ipv4')
-  $postgresql_ipv6 = hiera('profile::postgres::ipv6')
+  $postgresql_ipv6 = hiera('profile::postgres::ipv6', false)
 
   # We limit incoming requests to the management-network as it is only puppetdb
   # servers which needs postgres, and these live on this network.
@@ -25,12 +25,14 @@ class profile::services::postgresql::firewall {
     source      => $management_net,
     destination => $postgresql_ipv4,
   }
-  firewall { '071 ipv6 Accept incoming postgres requests':
-    proto       => 'tcp',
-    dport       => 5432,
-    action      => 'accept',
-    source      => $management_netv6,
-    destination => $postgresql_ipv6,
-    provider    => 'ip6tables',
+  if($postgresql_ipv6) {
+    firewall { '071 ipv6 Accept incoming postgres requests':
+      proto       => 'tcp',
+      dport       => 5432,
+      action      => 'accept',
+      source      => $management_netv6,
+      destination => $postgresql_ipv6,
+      provider    => 'ip6tables',
+    }
   }
 }

--- a/manifests/services/puppet/db/firewall.pp
+++ b/manifests/services/puppet/db/firewall.pp
@@ -2,15 +2,25 @@
 class profile::services::puppet::db::firewall {
   require ::firewall
 
-  firewall { '051 Accept incoming puppetdb':
-    proto  => 'tcp',
-    dport  => 8081,
-    action => 'accept',
+  $managementv4 = hiera('profile::networks::management::ipv4::prefix', false)
+  $managementv6 = hiera('profile::networks::management::ipv6::prefix', false)
+
+  if($managementv4) {
+    firewall { '051 Accept incoming puppetdb':
+      proto  => 'tcp',
+      dport  => 8081,
+      action => 'accept',
+      source => $managementv4,
+    }
   }
-  firewall { '051 ipv6 Accept incoming puppetdb':
-    proto    => 'tcp',
-    dport    => 8081,
-    action   => 'accept',
-    provider => 'ip6tables',
+
+  if($managementv6) {
+    firewall { '051 ipv6 Accept incoming puppetdb':
+      proto    => 'tcp',
+      dport    => 8081,
+      action   => 'accept',
+      provider => 'ip6tables',
+      source   => $managementv6,
+    }
   }
 }

--- a/manifests/services/puppet/server/firewall.pp
+++ b/manifests/services/puppet/server/firewall.pp
@@ -2,15 +2,25 @@
 class profile::services::puppet::server::firewall {
   require ::firewall
 
-  firewall { '050 Accept incoming puppet':
-    proto  => 'tcp',
-    dport  => 8140,
-    action => 'accept',
+  $managementv4 = hiera('profile::networks::management::ipv4::prefix', false)
+  $managementv6 = hiera('profile::networks::management::ipv6::prefix', false)
+
+  if($managementv4) {
+    firewall { '050 Accept incoming puppet':
+      proto  => 'tcp',
+      dport  => 8140,
+      action => 'accept',
+      source => $managementv4,
+    }
   }
-  firewall { '050 ipv6 Accept incoming puppet':
-    proto    => 'tcp',
-    dport    => 8140,
-    action   => 'accept',
-    provider => 'ip6tables',
+
+  if($managementv6) {
+    firewall { '050 ipv6 Accept incoming puppet':
+      proto    => 'tcp',
+      dport    => 8140,
+      action   => 'accept',
+      provider => 'ip6tables',
+      source   => $managementv6,
+    }
   }
 }

--- a/manifests/services/redis/firewall.pp
+++ b/manifests/services/redis/firewall.pp
@@ -1,15 +1,26 @@
 # Configure firewall for redis servers
 class profile::services::redis::firewall {
   require ::firewall
-  firewall { '050 accept redis-server':
-    proto  => 'tcp',
-    dport  => 6379,
-    action => 'accept',
+
+  $managementv4 = hiera('profile::networks::management::ipv4::prefix', false)
+  $managementv6 = hiera('profile::networks::management::ipv6::prefix', false)
+
+  if($managementv4) {
+    firewall { '050 accept redis-server':
+      proto  => 'tcp',
+      dport  => 6379,
+      action => 'accept',
+      source => $managementv4,
+    }
   }
-  firewall { '050 ipv6 accept redis-server':
-    proto    => 'tcp',
-    dport    => 6379,
-    action   => 'accept',
-    provider => 'ip6tables',
+
+  if($managementv6) {
+    firewall { '050 ipv6 accept redis-server':
+      proto    => 'tcp',
+      dport    => 6379,
+      action   => 'accept',
+      provider => 'ip6tables',
+      source   => $managementv6,
+    }
   }
 }


### PR DESCRIPTION
There are added some new hierakeys to help configure the hosts which are not getting DHCP.
IPv6 has become an opt-in in all classes, instead of being mandatory.

New hierakeys:
 - profile::interfaces::${name}::mtu - A certain interface's MTU
 - profile::dns::nameservers - A list over DNS servers to query for nameresolving
 - profile::dns::searchdomain - The DNS searchdomain
 - profile::interfaces::${name}::primary - Must be true to configure the default gateway on this interface. Should only be true on the management-interface.
 - 