### PR TITLE
Sensuupgrade

### DIFF
--- a/manifests/ceph/monitor.pp
+++ b/manifests/ceph/monitor.pp
@@ -13,6 +13,7 @@ class profile::ceph::monitor {
   $installsensu = hiera('profile::sensu::install', true)
   if ($installsensu) {
     include ::profile::sensu::plugin::ceph
+    sensu::subscription { 'roundrobin:ceph': }
   }
 
   require ::profile::ceph::base

--- a/manifests/sensu/checks.pp
+++ b/manifests/sensu/checks.pp
@@ -6,6 +6,7 @@ class profile::sensu::checks {
   contain ::profile::sensu::checks::certs
   contain ::profile::sensu::checks::dell
   contain ::profile::sensu::checks::haproxy
+  contain ::profile::sensu::checks::lvm
   contain ::profile::sensu::checks::memcached
   contain ::profile::sensu::checks::mysql
   contain ::profile::sensu::checks::physical

--- a/manifests/sensu/checks/lvm.pp
+++ b/manifests/sensu/checks/lvm.pp
@@ -1,7 +1,7 @@
 # Sensu checks for LVM
 class profile::sensu::checks::lvm {
   sensu::check { 'lvm-vg-usage':
-    command     => 'sudo check-vg-usage.rb -I ":::lvm.vg:::" -w ":::lvm.warn|85:::" -c ":::lvm.crit|95:::',
+    command     => 'sudo check-vg-usage.rb -I ":::lvm.vg:::" -w ":::lvm.warn|85:::" -c ":::lvm.crit|95:::"',
     interval    => 300,
     standalone  => false,
     subscribers => [ 'lvm-checks' ],

--- a/manifests/sensu/checks/lvm.pp
+++ b/manifests/sensu/checks/lvm.pp
@@ -1,0 +1,9 @@
+# Sensu checks for LVM
+class profile::sensu::checks::lvm {
+  sensu::check { 'lvm-vg-usage':
+    command     => 'sudo check-vg-usage.rb -I ":::lvm.vg:::" -w ":::lvm.warn|85:::" -c ":::lvm.crit|95:::',
+    interval    => 300,
+    standalone  => false,
+    subscribers => [ 'lvm-checks' ],
+  }
+}

--- a/manifests/sensu/client.pp
+++ b/manifests/sensu/client.pp
@@ -12,7 +12,7 @@ class profile::sensu::client {
     include ::profile::sensu::plugins
 
     if ( ! $rabbithost ) and ( ! $rabbithosts ) {
-      error('You need to specify either a single rabbithost, of a list of hosts')
+      error('You need to specify either a single rabbithost, or a list of hosts')
     }
 
     if ( $::is_virtual ) {

--- a/manifests/sensu/client.pp
+++ b/manifests/sensu/client.pp
@@ -18,7 +18,11 @@ class profile::sensu::client {
     if ( $::is_virtual ) {
       $subs = [ 'all' ]
     } else {
-      $subs = [ 'all', 'physical-servers' ]
+      if ( $::facts['dmi']['manufacturer'] =~ /Dell/ ) {
+        $subs = [ 'all', 'physical-servers', 'dell-servers']
+      } else {
+        $subs = [ 'all', 'physical-servers' ]
+      }
     }
 
     if ( $subs_from_client_conf != '' )  {

--- a/manifests/sensu/client.pp
+++ b/manifests/sensu/client.pp
@@ -3,12 +3,17 @@ class profile::sensu::client {
   $mgmt_nic = hiera('profile::interfaces::management', false)
 
   if($mgmt_nic) {
-    $rabbithost = hiera('profile::rabbitmq::ip')
+    $rabbithost = hiera('profile::rabbitmq::ip', false)
+    $rabbithosts = hiera('profile::rabbitmq::servers',false)
     $sensurabbitpass = hiera('profile::sensu::rabbit_password')
     $client_ip = getvar("::ipaddress_${mgmt_nic}")
     $subs_from_client_conf = hiera('sensu::subscriptions','')
 
     include ::profile::sensu::plugins
+
+    if ( ! $rabbithost ) and ( ! $rabbithosts ) {
+      error('You need to specify either a single rabbithost, of a list of hosts')
+    }
 
     if ( $::is_virtual ) {
       $subs = [ 'all' ]
@@ -22,18 +27,41 @@ class profile::sensu::client {
       $subscriptions = $subs
     }
 
+    if ( $rabbithosts ) {
+      $rabbit_cluster = $rabbithosts.map |$host| {
+        {
+          port      => 5672,
+          host      => $host,
+          user      => 'sensu',
+          password  => $sensurabbitpass,
+          vhost     => '/sensu',
+          heartbeat => 2,
+          prefetch  => 1,
+        }
+      }
+      $transport_conf = {
+        rabbitmq_cluster => $rabbit_cluster
+      }
+    } else {
+        $transport_conf = {
+          rabbitmq_host     => $rabbithost,
+          rabbitmq_user     => 'sensu',
+          rabbitmq_password => $sensurabbitpass,
+          rabbitmq_port     => 5672,
+        }
+    }
+
     class { '::sensu':
-      rabbitmq_host               => $rabbithost,
-      rabbitmq_password           => $sensurabbitpass,
-      rabbitmq_reconnect_on_error => true,
-      server                      => false,
-      api                         => false,
-      client                      => true,
-      client_address              => $client_ip,
-      sensu_plugin_provider       => 'sensu_gem',
-      use_embedded_ruby           => true,
-      subscriptions               => $subscriptions,
-      purge                       => true,
+      transport_reconnect_on_error => true,
+      server                       => false,
+      api                          => false,
+      client                       => true,
+      client_address               => $client_ip,
+      sensu_plugin_provider        => 'sensu_gem',
+      use_embedded_ruby            => true,
+      subscriptions                => $subscriptions,
+      purge                        => true,
+      *                            => $transport_conf,
     }
   }
 }

--- a/manifests/sensu/plugin/lvm.pp
+++ b/manifests/sensu/plugin/lvm.pp
@@ -1,0 +1,9 @@
+# lvm plugin for sensu
+class profile::sensu::plugin::lvm {
+
+  require ::profile::sensu::client
+
+  sensu::plugin { 'sensu-plugins-lvm':
+    type => 'package'
+  }
+}

--- a/manifests/sensu/server.pp
+++ b/manifests/sensu/server.pp
@@ -17,6 +17,7 @@ class profile::sensu::server {
 
   if ( ! $rabbithost ) and ( ! $rabbithosts ) {
     error('You need to specify either a single rabbithost, of a list of hosts')
+  }
 
   if ( $::is_virtual ) {
     $subs = [ 'all' ]

--- a/manifests/sensu/server.pp
+++ b/manifests/sensu/server.pp
@@ -67,6 +67,10 @@ class profile::sensu::server {
     sensu_plugin_provider        => 'sensu_gem',
     subscriptions                => $subscriptions,
     purge                        => true,
+    check_defaults               => {
+      'low_flap_threshold'  => 20,
+      'high_flap_threshold' => 30,
+    },
     *                            => $transport_conf,
   }
 

--- a/manifests/sensu/server.pp
+++ b/manifests/sensu/server.pp
@@ -16,7 +16,7 @@ class profile::sensu::server {
   $redismasterauth = hiera('profile::redis::masterauth')
 
   if ( ! $rabbithost ) and ( ! $rabbithosts ) {
-    error('You need to specify either a single rabbithost, of a list of hosts')
+    error('You need to specify either a single rabbithost, or a list of hosts')
   }
 
   if ( $::is_virtual ) {

--- a/manifests/sensu/server.pp
+++ b/manifests/sensu/server.pp
@@ -67,10 +67,6 @@ class profile::sensu::server {
     sensu_plugin_provider        => 'sensu_gem',
     subscriptions                => $subscriptions,
     purge                        => true,
-    check_defaults               => {
-      'low_flap_threshold'  => 20,
-      'high_flap_threshold' => 30,
-    },
     *                            => $transport_conf,
   }
 

--- a/manifests/sensu/server.pp
+++ b/manifests/sensu/server.pp
@@ -33,13 +33,15 @@ class profile::sensu::server {
 
   if ( $rabbithosts ) {
     $rabbit_cluster = $rabbithosts.map |$host| {
-      port      => 5672,
-      host      => $host,
-      user      => 'sensu',
-      password  => $sensurabbitpass,
-      vhost     => '/sensu',
-      heartbeat => 2,
-      prefetch  => 1,
+      {
+        port      => 5672,
+        host      => $host,
+        user      => 'sensu',
+        password  => $sensurabbitpass,
+        vhost     => '/sensu',
+        heartbeat => 2,
+        prefetch  => 1,
+      }
     }
     $transport_conf = {
       rabbitmq_cluster => $rabbit_cluster
@@ -52,7 +54,6 @@ class profile::sensu::server {
       rabbitmq_port     => 5672,
     }
   }
-
 
   class { '::sensu':
     transport_reconnect_on_error => true,

--- a/manifests/sensu/uchiwa.pp
+++ b/manifests/sensu/uchiwa.pp
@@ -7,14 +7,20 @@ class profile::sensu::uchiwa {
   $api_name = hiera('ntnuopenstack::region')
   $uchiwa_url = hiera('profile::sensu::uchiwa::fqdn')
 
+  $management_netv6 = hiera('profile::networks::management::ipv6::prefix', false)
   $management_if = hiera('profile::interfaces::management')
   $management_ipv4 = $::facts['networking']['interfaces'][$management_if]['ip']
-  $management_ipv6 = $::facts['networking']['interfaces'][$management_if]['ip6']
 
   $private_key = hiera('profile::sensu::uchiwa::private_key')
   $public_key  = hiera('profile::sensu::uchiwa::public_key')
   $private_key_path = '/etc/sensu/keys/uchiwa.rsa'
   $public_key_path  = '/etc/sensu/keys/uchiwa.rsa.pub'
+
+  if ( $management_netv6 ) {
+    $management_ipv6 = $::facts['networking']['interfaces'][$management_if]['ip6']
+  } else {
+    $management_ipv6 = ''
+  }
 
   class { '::uchiwa':
     user                => 'sensu',

--- a/manifests/services/haproxy.pp
+++ b/manifests/services/haproxy.pp
@@ -92,5 +92,6 @@ ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256"
   }
   if ($installsensu) {
     include ::profile::sensu::plugin::haproxy
+    sensu::subscription { 'haproxy-servers': }
   }
 }

--- a/manifests/services/libvirt/pools.pp
+++ b/manifests/services/libvirt/pools.pp
@@ -21,5 +21,6 @@ class profile::services::libvirt::pools {
   $installsensu = hiera('profile::sensu::install', true)
   if ($installsensu) {
     include ::profile::sensu::plugin::lvm
+    sensu::subscription { 'lvm-checks': }
   }
 }

--- a/manifests/services/libvirt/pools.pp
+++ b/manifests/services/libvirt/pools.pp
@@ -17,4 +17,9 @@ class profile::services::libvirt::pools {
   libvirt_pool { 'images':
     ensure => absent,
   }
+
+  $installsensu = hiera('profile::sensu::install', true)
+  if ($installsensu) {
+    include ::profile::sensu::plugin::lvm
+  }
 }

--- a/manifests/services/memcache.pp
+++ b/manifests/services/memcache.pp
@@ -32,6 +32,7 @@ class profile::services::memcache {
 
   if ($installsensu) {
     include ::profile::sensu::plugin::memcached
+    sensu::subscription { 'memcached': }
   }
   if($installmunin) {
     include ::profile::monitoring::munin::plugin::memcached

--- a/manifests/services/mysql.pp
+++ b/manifests/services/mysql.pp
@@ -6,12 +6,13 @@ class profile::services::mysql {
   include ::profile::services::mysql::haproxy::backend
   include ::profile::services::mysql::users
 
-  $installMunin = hiera('profile::munin::install', true)
-  if($installMunin) {
+  $installmunin = hiera('profile::munin::install', true)
+  if($installmunin) {
     include ::profile::monitoring::munin::plugin::mysql
   }
   $installsensu = hiera('profile::sensu::install', true)
   if ($installsensu) {
     include ::profile::sensu::plugin::mysql
+    sensu::subscription { 'mysql': }
   }
 }

--- a/manifests/services/rabbitmq.pp
+++ b/manifests/services/rabbitmq.pp
@@ -68,5 +68,6 @@ class profile::services::rabbitmq {
   if ($install_sensu) {
     include ::profile::services::rabbitmq::sensu
     include ::profile::sensu::plugin::rabbitmq
+    sensu::subscription { 'rabbitmq': }
   }
 }

--- a/manifests/services/rabbitmq/sensu.pp
+++ b/manifests/services/rabbitmq/sensu.pp
@@ -2,19 +2,31 @@
 class profile::services::rabbitmq::sensu {
 
   $sensurabbitpass = hiera('profile::sensu::rabbit_password')
+  $rabbithosts = hiera('profile::rabbitmq::servers', false)
 
   rabbitmq_user { 'sensu':
     admin    => false,
     password => $sensurabbitpass,
     provider => 'rabbitmqctl',
-  } ->
-  rabbitmq_vhost { '/sensu':
+  }
+  -> rabbitmq_vhost { '/sensu':
     ensure => 'present',
-  } ->
-  rabbitmq_user_permissions { 'sensu@/sensu':
+  }
+  -> rabbitmq_user_permissions { 'sensu@/sensu':
     configure_permission => '.*',
     write_permission     => '.*',
     read_permission      => '.*',
     provider             => 'rabbitmqctl',
+  }
+
+  if ( $rabbithosts ) {
+    rabbitmq_policy { 'ha-sensu@/sensu':
+      pattern    => '^(results$|keepalives$)',
+      definition => {
+        'ha-mode'      => 'all',
+        'ha-sync-mode' => 'automatic',
+      },
+      after      => Rabbitmq_vhost['/sensu']
+    }
   }
 }

--- a/manifests/services/rabbitmq/sensu.pp
+++ b/manifests/services/rabbitmq/sensu.pp
@@ -26,7 +26,7 @@ class profile::services::rabbitmq::sensu {
         'ha-mode'      => 'all',
         'ha-sync-mode' => 'automatic',
       },
-      after      => Rabbitmq_vhost['/sensu']
+      require    => Rabbitmq_vhost['/sensu']
     }
   }
 }

--- a/manifests/services/redis.pp
+++ b/manifests/services/redis.pp
@@ -70,7 +70,7 @@ class profile::services::redis {
   if ($installsensu) {
     include ::profile::sensu::plugin::redis
     sensu::subscription { 'redis': }
-    sensu::config { 'redis': {
+    sensu::config { 'redis':
       config => {
         masterauth => $masterauth,
       },

--- a/manifests/services/redis.pp
+++ b/manifests/services/redis.pp
@@ -70,10 +70,6 @@ class profile::services::redis {
   if ($installsensu) {
     include ::profile::sensu::plugin::redis
     sensu::subscription { 'redis': }
-    sensu::config { 'redis':
-      config => {
-        masterauth => $masterauth,
-      },
     }
   }
 }

--- a/manifests/services/redis.pp
+++ b/manifests/services/redis.pp
@@ -70,6 +70,5 @@ class profile::services::redis {
   if ($installsensu) {
     include ::profile::sensu::plugin::redis
     sensu::subscription { 'redis': }
-    }
   }
 }

--- a/manifests/services/redis.pp
+++ b/manifests/services/redis.pp
@@ -70,5 +70,10 @@ class profile::services::redis {
   if ($installsensu) {
     include ::profile::sensu::plugin::redis
     sensu::subscription { 'redis': }
+    sensu::config { 'redis': {
+      config => {
+        masterauth => $masterauth,
+      },
+    }
   }
 }

--- a/manifests/services/redis.pp
+++ b/manifests/services/redis.pp
@@ -69,5 +69,6 @@ class profile::services::redis {
 
   if ($installsensu) {
     include ::profile::sensu::plugin::redis
+    sensu::subscription { 'redis': }
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -13,9 +13,9 @@
     { "name":"example42/network","version_requirement":">= 3.3.8 < 4.0.0" },
     { "name":"inkblot/ipcalc","version_requirement":">= 2.2.0 < 3.0.0" },
     { "name":"puppetlabs/concat","version_requirement":">= 1.2.5 < 5.0.0" },
-    { "name":"puppetlabs/stdlib","version_requirement":">= 4.15.0 < 5.0.0" },
+    { "name":"puppetlabs/stdlib","version_requirement":">= 4.24.0 < 5.0.0" },
     { "name":"puppetlabs/inifile","version_requirement":">= 1.5.0 < 2.0.0" },
-    { "name":"ntnusky/ntnuopenstack","version_requirement":">= 1.0.0 < 5.0.0" }
+    { "name":"ntnusky/ntnuopenstack","version_requirement":">= 1.0.0 < 5.0.0" },
     { "name":"puppet/rabbitmq","version_requirement":">= 8.2.2 < 9.0.0" }
   ],
   "data_provider": "hiera",


### PR DESCRIPTION
Essentially: Make servers and clients use the rabbit cluster, move most of the subscriptions to puppet, rather than defining them per node in hiera, and added  a new check for our KVM-hosts.