### PR TITLE
Mounts and default vhost docroot

### DIFF
--- a/manifests/baseconfig.pp
+++ b/manifests/baseconfig.pp
@@ -2,6 +2,7 @@
 class profile::baseconfig {
   include ::profile::baseconfig::firewall
   include ::profile::baseconfig::git
+  include ::profile::baseconfig::mounts
   include ::profile::baseconfig::networking
   include ::profile::baseconfig::ntp
   include ::profile::baseconfig::packages

--- a/manifests/baseconfig/mounts.pp
+++ b/manifests/baseconfig/mounts.pp
@@ -1,0 +1,10 @@
+# This class reads a list of mounts from hiera, and makes sure to define them.
+class profile::baseconfig::mounts {
+  $mounts = hiera_hash('profile::mounts', false)
+
+  $mounts.each | $path, $options | {
+    mount { $path:
+      * => $options,
+    }
+  }
+}

--- a/manifests/baseconfig/mounts.pp
+++ b/manifests/baseconfig/mounts.pp
@@ -3,8 +3,16 @@ class profile::baseconfig::mounts {
   $mounts = hiera_hash('profile::mounts', false)
 
   $mounts.each | $path, $options | {
+    file { $path:
+      ensure => 'directory',
+      owner  => 'root',
+      group  => 'root',
+      mode   => '0700',
+    }
+
     mount { $path:
-      * => $options,
+      require => File[$path],
+      *       => $options,
     }
   }
 }

--- a/manifests/services/apache.pp
+++ b/manifests/services/apache.pp
@@ -2,6 +2,9 @@
 # vhost for the fqdn of the host
 class profile::services::apache {
   $management_if = hiera('profile::interfaces::management')
+  $default_docroot = hiera('profile::apache::vhost::default::docroot',
+      "/var/www/${::fqdn}")
+
   $management_ipv4 = $::facts['networking']['interfaces'][$management_if]['ip']
   $management_ipv6 = $::facts['networking']['interfaces'][$management_if]['ip6']
 
@@ -23,16 +26,14 @@ class profile::services::apache {
     port          => '80',
     ip            => concat([], $management_ipv4, $management_ipv6),
     add_listen    => false,
-    docroot       => "/var/www/${::fqdn}",
+    docroot       => $default_docroot,
     docroot_owner => 'www-data',
     docroot_group => 'www-data',
   }
-
 
   include ::apache::mod::rewrite
   include ::apache::mod::prefork
   include ::apache::mod::php
   include ::apache::mod::ssl
   include ::profile::services::apache::firewall
-
 }


### PR DESCRIPTION
Added the possibility to add mountpoints in hiera, which puppet then configures on the host.
Added a hierakey in profile::services::apache to allow setting the docroot of the default vhost.

New hierakeys:
 - profile::mounts: Should be a hash, where the key is the mountpoints, and the value is a new hash with the keys "device", "ensure" and "fstype"
 - profile::apache::vhost::default::docroot: Should be a full path to the folder which should be the docroot.