### PR TITLE
Munin monitoring of ceph activity

### DIFF
--- a/manifests/ceph/firewall/monitor.pp
+++ b/manifests/ceph/firewall/monitor.pp
@@ -2,16 +2,47 @@
 class profile::ceph::firewall::monitor {
   require ::profile::baseconfig::firewall
 
-  $public_networks = hiera_array('profile::ceph::public_networks')
-  $storage_interface = hiera('profile::interfaces::storage')
+  $ceph_public = lookup('profile::ceph::public_networks', {
+    'variable_type' => Array,
+    'default_value' => [],
+  })
+  $mgmtv4_nets = lookup('profile::networking::management::ipv4::prefixes', {
+    'variable_type' => Array,
+    'default_value' => [],
+  })
+  $mgmtv6_nets = lookup('profile::networking::management::ipv6::prefixes', {
+    'variable_type' => Array,
+    'default_value' => [],
+  })
+  $storage_interface = lookup('profile::interfaces::storage', String)
 
-  $public_networks.each | $net | {
+  # Allow ceph-cluster traffic
+  $ceph_public.each | $net | {
     firewall { "200 accept incoming traffic for ceph monitor from ${net}":
       source  => $net,
       iniface => $storage_interface,
       proto   => 'tcp',
       dport   => [ '6789' ],
       action  => 'accept',
+    }
+  }
+
+  # Allow traffic to the dashboard from the management networks.
+  $mgmtv4_nets.each | $net | {
+    firewall { "300 accept incoming traffic for ceph dashboard from ${net}":
+      source  => $net,
+      proto   => 'tcp',
+      dport   => [ '7000' ],
+      action  => 'accept',
+    }
+  }
+  $mgmtv6_nets.each | $net | {
+    firewall { "300 accept incoming traffic for ceph dashboard from ${net}":
+      source   => $net,
+      proto    => 'tcp',
+      dport    => [ '7000' ],
+      action   => 'accept',
+      provider => 'ip6tables',
     }
   }
 }

--- a/manifests/ceph/firewall/monitor.pp
+++ b/manifests/ceph/firewall/monitor.pp
@@ -3,15 +3,15 @@ class profile::ceph::firewall::monitor {
   require ::profile::baseconfig::firewall
 
   $ceph_public = lookup('profile::ceph::public_networks', {
-    'value_type' => Array,
+    'value_type' => Array[String],
     'default_value' => [],
   })
   $mgmtv4_nets = lookup('profile::networking::management::ipv4::prefixes', {
-    'value_type' => Array,
+    'value_type' => Array[String],
     'default_value' => [],
   })
   $mgmtv6_nets = lookup('profile::networking::management::ipv6::prefixes', {
-    'value_type' => Array,
+    'value_type' => Array[String],
     'default_value' => [],
   })
   $storage_interface = lookup('profile::interfaces::storage', String)

--- a/manifests/ceph/firewall/monitor.pp
+++ b/manifests/ceph/firewall/monitor.pp
@@ -3,15 +3,15 @@ class profile::ceph::firewall::monitor {
   require ::profile::baseconfig::firewall
 
   $ceph_public = lookup('profile::ceph::public_networks', {
-    'variable_type' => Array,
+    'value_type' => Array,
     'default_value' => [],
   })
   $mgmtv4_nets = lookup('profile::networking::management::ipv4::prefixes', {
-    'variable_type' => Array,
+    'value_type' => Array,
     'default_value' => [],
   })
   $mgmtv6_nets = lookup('profile::networking::management::ipv6::prefixes', {
-    'variable_type' => Array,
+    'value_type' => Array,
     'default_value' => [],
   })
   $storage_interface = lookup('profile::interfaces::storage', String)


### PR DESCRIPTION
There is a bug in the v1.5.2 release, as munin tries to use the ceph dashboard to retrieve metrics while the firewalls does not allow it.

This release opens the firewall to allow munin to retrieve statistics from the ceph dashboard.