### PR TITLE
Anycast, New firewalling, Ceph map.

### DIFF
--- a/manifests/baseconfig/firewall/service/global.pp
+++ b/manifests/baseconfig/firewall/service/global.pp
@@ -1,0 +1,20 @@
+# Punch a hole in the firewall to allow global access to a service
+define profile::baseconfig::firewall::service::global (
+  Variant[Integer, Array[Integer]] $port,
+  String                           $protocol,
+) {
+  require ::profile::baseconfig::firewall
+
+  firewall { "5 Accept global access to service ${name}":
+    proto  => $protocol,
+    dport  => $port,
+    action => 'accept',
+  }
+
+  firewall { "5 Accept global access to service ${name}":
+    proto    => $protocol,
+    dport    => $port,
+    action   => 'accept',
+    provider => 'ip6tables',
+  }
+}

--- a/manifests/baseconfig/firewall/service/global.pp
+++ b/manifests/baseconfig/firewall/service/global.pp
@@ -1,7 +1,7 @@
 # Punch a hole in the firewall to allow global access to a service
 define profile::baseconfig::firewall::service::global (
-  Variant[Integer, Array[Integer]] $port,
-  String                           $protocol,
+  Variant[Integer, Array[Integer], String] $port,
+  String                                   $protocol,
 ) {
   require ::profile::baseconfig::firewall
 

--- a/manifests/baseconfig/firewall/service/global.pp
+++ b/manifests/baseconfig/firewall/service/global.pp
@@ -5,13 +5,13 @@ define profile::baseconfig::firewall::service::global (
 ) {
   require ::profile::baseconfig::firewall
 
-  firewall { "5 Accept global access to service ${name}":
+  firewall { "5 Accept global v4 access to service ${name}":
     proto  => $protocol,
     dport  => $port,
     action => 'accept',
   }
 
-  firewall { "5 Accept global access to service ${name}":
+  firewall { "5 Accept global v6 access to service ${name}":
     proto    => $protocol,
     dport    => $port,
     action   => 'accept',

--- a/manifests/baseconfig/firewall/service/infra.pp
+++ b/manifests/baseconfig/firewall/service/infra.pp
@@ -1,0 +1,37 @@
+# Punch a hole in the firewall to allow all our infra-net access to a certain
+# service.
+define profile::baseconfig::firewall::service::infra (
+  Variant[Integer, Array[Integer]] $port,
+  String                           $protocol,
+) {
+  require ::profile::baseconfig::firewall
+
+  $infrav4 = lookup('profile::networking::infrastructure::ipv4::prefixes', {
+    'value_type' => Array[Stdlib::IP::Address::V4::CIDR],
+    'merge'      => 'unique',
+  })
+  $infrav6 = lookup('profile::networking::infrastructure::ipv6::prefixes', {
+    'value_type'    => Array[Stdlib::IP::Address::V6::CIDR],
+    'merge'         => 'unique',
+    'default_value' => [],
+  })
+
+  $infrav4.each | $net | {
+    firewall { "5 Accept service ${name} from ${net}":
+      proto  => $protocol,
+      dport  => $port,
+      action => 'accept',
+      source => $net,
+    }
+  }
+
+  $infrav6.each | $net | {
+    firewall { "5 Accept service ${name} from ${net}":
+      proto    => $protocol,
+      dport    => $port,
+      action   => 'accept',
+      source   => $net,
+      provider => 'ip6tables',
+    }
+  }
+}

--- a/manifests/baseconfig/firewall/service/infra.pp
+++ b/manifests/baseconfig/firewall/service/infra.pp
@@ -1,8 +1,8 @@
 # Punch a hole in the firewall to allow all our infra-net access to a certain
 # service.
 define profile::baseconfig::firewall::service::infra (
-  Variant[Integer, Array[Integer]] $port,
-  String                           $protocol,
+  Variant[Integer, Array[Integer], String] $port,
+  String                                   $protocol,
 ) {
   require ::profile::baseconfig::firewall
 

--- a/manifests/baseconfig/firewall/service/management.pp
+++ b/manifests/baseconfig/firewall/service/management.pp
@@ -1,8 +1,8 @@
 # Punch a hole in the firewall to allow all our management networks access to a 
 # certain service.
 define profile::baseconfig::firewall::service::management (
-  Variant[Integer, Array[Integer]] $port,
-  String                           $protocol,
+  Variant[Integer, Array[Integer], String] $port,
+  String                                   $protocol,
 ) {
   require ::profile::baseconfig::firewall
 

--- a/manifests/baseconfig/firewall/service/management.pp
+++ b/manifests/baseconfig/firewall/service/management.pp
@@ -1,0 +1,37 @@
+# Punch a hole in the firewall to allow all our management networks access to a 
+# certain service.
+define profile::baseconfig::firewall::service::management (
+  Variant[Integer, Array[Integer]] $port,
+  String                           $protocol,
+) {
+  require ::profile::baseconfig::firewall
+
+  $infrav4 = lookup('profile::networking::management::ipv4::prefixes', {
+    'value_type' => Array[Stdlib::IP::Address::V4::CIDR],
+    'merge'      => 'unique',
+  })
+  $infrav6 = lookup('profile::networking::management::ipv6::prefixes', {
+    'value_type'    => Array[Stdlib::IP::Address::V6::CIDR],
+    'merge'         => 'unique',
+    'default_value' => [],
+  })
+
+  $infrav4.each | $net | {
+    firewall { "5 Accept service ${name} from ${net}":
+      proto  => $protocol,
+      dport  => $port,
+      action => 'accept',
+      source => $net,
+    }
+  }
+
+  $infrav6.each | $net | {
+    firewall { "5 Accept service ${name} from ${net}":
+      proto    => $protocol,
+      dport    => $port,
+      action   => 'accept',
+      source   => $net,
+      provider => 'ip6tables',
+    }
+  }
+}

--- a/manifests/baseconfig/networking.pp
+++ b/manifests/baseconfig/networking.pp
@@ -7,7 +7,7 @@ class profile::baseconfig::networking {
     profile::baseconfig::configureinterface { $if_to_configure: }
   }
 
-  # Trust ICMP redirects. This is sage as long as the secure_redirect is set
+  # Trust ICMP redirects. This is safe as long as the secure_redirect is set
   # because the host would then only trust redirects from hosts acting as a
   # gateway.
   sysctl::value { 'net.ipv4.conf.all.accept_redirects':

--- a/manifests/baseconfig/networking.pp
+++ b/manifests/baseconfig/networking.pp
@@ -7,6 +7,16 @@ class profile::baseconfig::networking {
     profile::baseconfig::configureinterface { $if_to_configure: }
   }
 
+  # Trust ICMP redirects. This is sage as long as the secure_redirect is set
+  # because the host would then only trust redirects from hosts acting as a
+  # gateway.
+  sysctl::value { 'net.ipv4.conf.all.accept_redirects':
+    value => '1',
+  }
+  sysctl::value { 'net.ipv6.conf.all.accept_redirects':
+    value => '1',
+  }
+
   # Disable the rpfilter if that is desirable. This is needed if we are not
   # using multiple routing-tables on hosts where there is more than one nic.
   $rp_filter = hiera('profile::networking::rpfilter', false)

--- a/manifests/bird.pp
+++ b/manifests/bird.pp
@@ -1,0 +1,5 @@
+# Installs and configures the bird routing-daemon
+class profile::bird {
+  include ::profile::bird::ipv4
+  include ::profile::bird::ipv6
+}

--- a/manifests/bird/config/bgp.pp
+++ b/manifests/bird/config/bgp.pp
@@ -1,0 +1,19 @@
+# Configures bird to communicate using bgp
+define profile::bird::config::bgp (
+  String $configfile,
+  String $filtername,
+  Integer $aslocal,
+  Integer $asremote,
+  String $neighbourip,
+) {
+  concat::fragment { "Bird BGP ${name}":
+    target  => $configfile,
+    content => epp('profile/bird/bgp.epp', {
+      'filtername'  => $filtername,
+      'aslocal'     => $aslocal,
+      'asremote'    => $asremote,
+      'neighbourIP' => $neighbourip,
+    }),
+    order   => '15'
+  }
+}

--- a/manifests/bird/config/filter.pp
+++ b/manifests/bird/config/filter.pp
@@ -1,0 +1,14 @@
+# Creates a filter in some bird-config 
+define profile::bird::config::filter (
+  String $configfile,
+  Array $prefixes,
+) {
+  concat::fragment { "Bird Filter ${name}":
+    target  => $configfile,
+    content => epp('profile/bird/filter.epp', {
+      'name'     => $name,
+      'prefixes' => $prefixes,
+    }),
+    order   => '10'
+  }
+}

--- a/manifests/bird/config/ipv4.pp
+++ b/manifests/bird/config/ipv4.pp
@@ -1,0 +1,40 @@
+# Provides the base-configuration of bird for IPv4
+class profile::bird::config::ipv4 {
+  require ::profile::bird::install
+  include ::profile::bird::service::ipv4
+
+  # Determine the management IP. Either select the first found on the management
+  # interface, or use the IP set in hiera, if there are an IP in hiera.
+  $management_if = lookup('profile::interfaces::management', String)
+  $management_auto4 = $facts['networking']['interfaces'][$management_if]['ip']
+  $management_ipv4 = lookup("profile::interfaces::${management_if}::address", {
+    'value_type'    => String,
+    'default_value' => $management_auto4,
+  })
+
+  # If a router-id is set in hiera; use it. Otherwise, use the IP from the
+  # management interface.
+  $router_id = lookup('profile::bird::router::id', {
+    'value_type'    => String,
+    'default_value' => $management_ipv4,
+  })
+
+  concat { '/etc/bird/bird.conf':
+    ensure         => present,
+    ensure_newline => true,
+    notify         => Service['bird'],
+    warn           => true,
+  }
+
+  concat::fragment { 'Bird4 RouterID':
+    target  => '/etc/bird/bird.conf',
+    content => "router id ${router_id};",
+    order   => '01'
+  }
+
+  concat::fragment { 'Bird4 General':
+    target  => '/etc/bird/bird.conf',
+    content => epp('profile/bird/general.epp'),
+    order   => '05'
+  }
+}

--- a/manifests/bird/config/ipv6.pp
+++ b/manifests/bird/config/ipv6.pp
@@ -1,0 +1,46 @@
+# Provides the base-configuration of bird for IPv6
+class profile::bird::config::ipv6 {
+  require ::profile::bird::install
+  include ::profile::bird::service::ipv6
+
+  # Determine the management IP. Either select the first found on the management
+  # interface, or use the IP set in hiera, if there are an IP in hiera.
+  $management_if = lookup('profile::interfaces::management', String)
+  $management_auto4 = $facts['networking']['interfaces'][$management_if]['ip']
+  $management_ipv4 = lookup("profile::interfaces::${management_if}::address", {
+    'value_type'    => String,
+    'default_value' => $management_auto4,
+  })
+
+  # If a router-id is set in hiera; use it. Otherwise, use the IP from the
+  # management interface.
+  $router_id = lookup('profile::bird::router::id', {
+    'value_type'    => String,
+    'default_value' => $management_ipv4,
+  })
+
+  concat { '/etc/bird/bird6.conf':
+    ensure         => present,
+    ensure_newline => true,
+    notify         => Service['bird6'],
+    warn           => true,
+  }
+
+  concat::fragment { 'Bird6 RouterID':
+    target  => '/etc/bird/bird6.conf',
+    content => "router id ${router_id};",
+    order   => '01',
+  }
+
+  concat::fragment { 'Bird6 Listen BGP':
+    target  => '/etc/bird/bird6.conf',
+    content => 'listen bgp v6only;',
+    order   => '02',
+  }
+
+  concat::fragment { 'Bird6 General':
+    target  => '/etc/bird/bird6.conf',
+    content => epp('profile/bird/general.epp'),
+    order   => '05',
+  }
+}

--- a/manifests/bird/install.pp
+++ b/manifests/bird/install.pp
@@ -1,0 +1,6 @@
+# Installs the bird routing-daemon
+class profile::bird::install {
+  package { 'bird':
+    ensure => 'present',
+  }
+}

--- a/manifests/bird/ipv4.pp
+++ b/manifests/bird/ipv4.pp
@@ -1,0 +1,35 @@
+# Installs and configures bird for IPv6 if there is defined an IPv6 address in
+# hiera under the key 'profile::bird::anycast::ipv6::address' 
+class profile::bird::ipv4 {
+  $anycastv4 = lookup('profile::bird::anycast::ipv4::address', {
+    'value_type'    => Variant[String, Boolean],
+    'default_value' => false,
+  })
+
+  if($anycastv4) {
+    include ::profile::bird::config::ipv4
+
+    $local_as = lookup('profile::bird::anycast::ipv4::bgp::as::local', {
+      'value_type'    => Integer,
+    })
+    $remote_as = lookup('profile::bird::anycast::ipv4::bgp::as::remote', {
+      'value_type'    => Integer,
+    })
+    $neighbour = lookup('profile::bird::anycast::ipv4::bgp::peer', {
+      'value_type'    => String,
+    })
+
+    ::profile::bird::config::bgp { 'v4anycast':
+      configfile  => '/etc/bird/bird.conf',
+      filtername  => 'v4anycast',
+      aslocal     => $local_as,
+      asremote    => $remote_as,
+      neighbourip => $neighbour,
+    }
+
+    ::profile::bird::config::filter { 'v4anycast':
+      configfile => '/etc/bird/bird.conf',
+      prefixes   => [ "${anycastv4}/32" ],
+    }
+  }
+}

--- a/manifests/bird/ipv6.pp
+++ b/manifests/bird/ipv6.pp
@@ -1,0 +1,35 @@
+# Installs and configures bird for IPv6 if there is defined an IPv6 address in
+# hiera under the key 'profile::bird::anycast::ipv6::address' 
+class profile::bird::ipv6 {
+  $anycastv6 = lookup('profile::bird::anycast::ipv6::address', {
+    'value_type'    => Variant[String, Boolean],
+    'default_value' => false,
+  })
+
+  if($anycastv6) {
+    include ::profile::bird::config::ipv6
+
+    $local_as = lookup('profile::bird::anycast::ipv6::bgp::as::local', {
+      'value_type'    => Integer,
+    })
+    $remote_as = lookup('profile::bird::anycast::ipv6::bgp::as::remote', {
+      'value_type'    => Integer,
+    })
+    $neighbour = lookup('profile::bird::anycast::ipv6::bgp::peer', {
+      'value_type'    => String,
+    })
+
+    ::profile::bird::config::bgp { 'v6anycast':
+      configfile  => '/etc/bird/bird6.conf',
+      filtername  => 'v6anycast',
+      aslocal     => $local_as,
+      asremote    => $remote_as,
+      neighbourip => $neighbour,
+    }
+
+    ::profile::bird::config::filter { 'v6anycast':
+      configfile => '/etc/bird/bird6.conf',
+      prefixes   => [ "${anycastv6}/128" ],
+    }
+  }
+}

--- a/manifests/bird/service/ipv4.pp
+++ b/manifests/bird/service/ipv4.pp
@@ -1,0 +1,10 @@
+# Defines the bird service
+class profile::bird::service::ipv4 {
+  include ::profile::bird::install
+
+  service { 'bird':
+    ensure  => 'running',
+    enable  => true,
+    require => Package['bird'],
+  }
+}

--- a/manifests/bird/service/ipv6.pp
+++ b/manifests/bird/service/ipv6.pp
@@ -1,0 +1,10 @@
+# Defines the bird service for ipv6
+class profile::bird::service::ipv6 {
+  include ::profile::bird::install
+
+  service { 'bird6':
+    ensure  => 'running',
+    enable  => true,
+    require => Package['bird'],
+  }
+}

--- a/manifests/ceph/client.pp
+++ b/manifests/ceph/client.pp
@@ -13,7 +13,7 @@ class profile::ceph::client {
       value => true;
   }
 
-  ensure_packages ( 'rbd-nbd', {
+  ensure_packages ( ['rbd-nbd'], {
     'ensure' => 'present',
   })
 }

--- a/manifests/ceph/client.pp
+++ b/manifests/ceph/client.pp
@@ -12,4 +12,8 @@ class profile::ceph::client {
     'client/rbd cache writethrough until flush':
       value => true;
   }
+
+  ensure_packages ( 'rbd-nbd', {
+    'ensure' => 'present',
+  })
 }

--- a/manifests/services/apache/firewall.pp
+++ b/manifests/services/apache/firewall.pp
@@ -1,15 +1,7 @@
 # This class configures firewall rules for apache port 80,443
 class profile::services::apache::firewall {
-  require ::profile::baseconfig::firewall 
-  firewall { '504 accept incoming HTTP, HTTPS':
-    proto  => 'tcp',
-    dport  => [80,443],
-    action => 'accept',
-  }
-  firewall { '504 v6accept incoming HTTP, HTTPS':
-    proto    => 'tcp',
-    dport    => [80,443],
-    action   => 'accept',
-    provider => 'ip6tables',
+  ::profile::baseconfig::firewall::service::global { 'WEB':
+    protocol => 'tcp',
+    port     => [80,443],
   }
 }

--- a/manifests/services/dashboard/dev/firewall.pp
+++ b/manifests/services/dashboard/dev/firewall.pp
@@ -1,29 +1,7 @@
 # This class configures the firewall, to open it for the dev-server
 class profile::services::dashboard::dev::firewall {
-  $ipv4_management_nets = lookup(
-      'profile::networking::management::ipv4::prefixes',
-      Array, 'unique', [])
-  $ipv6_management_nets = lookup(
-      'profile::networking::management::ipv6::prefixes',
-      Array, 'unique', [])
-
-  require ::profile::baseconfig::firewall
-
-  $ipv4_management_nets.each |$net| {
-    firewall { "700 Accept the dev-server from ${net}":
-      proto  => 'tcp',
-      dport  => [8080],
-      action => 'accept',
-      source => $net,
-    }
-  }
-  $ipv6_management_nets.each |$net| {
-    firewall { "700 Accept the dev-server from ${net}":
-      proto    => 'tcp',
-      dport    => [8080],
-      action   => 'accept',
-      provider => 'ip6tables',
-      source   => $net,
-    }
+  ::profile::baseconfig::firewall::service::management { 'Shiftleader-dev':
+    port     => 8080,
+    protocol => 'tcp',
   }
 }

--- a/manifests/services/dhcp/firewall.pp
+++ b/manifests/services/dhcp/firewall.pp
@@ -1,39 +1,11 @@
 # This class configures firewall rules for DHCP 
 class profile::services::dhcp::firewall {
-  require ::profile::baseconfig::firewall
-
-  $infrav4 = lookup('profile::networking::infrastructure::ipv4::prefixes', {
-    'value_type' => Array[Stdlib::IP::Address::V4::CIDR],
-    'merge'      => 'unique',
-  })
-  $infrav6 = lookup('profile::networking::infrastructure::ipv6::prefixes', {
-    'value_type'    => Array[Stdlib::IP::Address::V6::CIDR],
-    'merge'         => 'unique',
-    'default_value' => [],
-  })
-
-  firewall { '400 accept incoming DHCP':
-    proto  => 'udp',
-    sport  => [67,68],
-    dport  => [67,68],
-    action => 'accept',
+  ::profile::baseconfig::firewall::service::infra { 'DHCP OMAPI':
+    protocol => 'tcp',
+    port     => 7911,
   }
-
-  $infrav4.each | $net | {
-    firewall { "400 Accept incoming OMAPI requests from ${net}":
-      proto  => 'tcp',
-      dport  => 7911,
-      action => 'accept',
-      source => $net,
-    }
-  }
-  $infrav6.each | $net | {
-    firewall { "400 Accept incoming OMAPI requests from ${net}":
-      proto    => 'tcp',
-      dport    => 7911,
-      action   => 'accept',
-      source   => $net,
-      provider => 'ip6tables',
-    }
+  ::profile::baseconfig::firewall::service::global { 'DHCP':
+    protocol => 'udp',
+    port     => [67,68],
   }
 }

--- a/manifests/services/dns/firewall.pp
+++ b/manifests/services/dns/firewall.pp
@@ -1,27 +1,11 @@
 # This class configures firewall rules for DNS 
 class profile::services::dns::firewall {
-  require ::profile::baseconfig::firewall 
-
-  firewall { '400 accept incoming DNS':
-    proto  => 'udp',
-    dport  => [53],
-    action => 'accept',
+  ::profile::baseconfig::firewall::service::global { 'TCP DNS':
+    port     => 53,
+    protocol => 'tcp',
   }
-  firewall { '401 accept incoming DNS':
-    proto  => 'tcp',
-    dport  => [53],
-    action => 'accept',
-  }
-  firewall { '400 ipv6 accept incoming DNS':
-    proto    => 'udp',
-    dport    => [53],
-    action   => 'accept',
-    provider => 'ip6tables',
-  }
-  firewall { '401 ipv6 accept incoming DNS':
-    proto    => 'tcp',
-    dport    => [53],
-    action   => 'accept',
-    provider => 'ip6tables',
+  ::profile::baseconfig::firewall::service::global { 'UDP DNS':
+    port     => 53,
+    protocol => 'udp',
   }
 }

--- a/manifests/services/haproxy/frontend.pp
+++ b/manifests/services/haproxy/frontend.pp
@@ -1,0 +1,60 @@
+# Configures a generic haproxy frontend
+define profile::services::haproxy::frontend (
+  String  $profile,
+  Integer $port,
+  Hash    $ftoptions = {},
+  Hash    $bkoptions = {},
+) {
+  require ::profile::services::haproxy
+
+  # Collect the addresses to bind to; or get false if the address is not used.
+  $anycastv4 = lookup("profile::anycast::${profile}::ipv4", {
+    'value_type'    => Variant[Stdlib::IP::Address::V4, Boolean],
+    'default_value' => false,
+  })
+  $anycastv6 = lookup("profile::anycast::${profile}::ipv6", {
+    'value_type'    => Variant[Stdlib::IP::Address::V6, Boolean],
+    'default_value' => false,
+  })
+  $keepalivedipv4 = lookup("profile::haproxy::${profile}::ipv4", {
+    'value_type'    => Variant[Stdlib::IP::Address::V4, Boolean],
+    'default_value' => false,
+  })
+  $keepalivedipv6 = lookup("profile::haproxy::${profile}::ipv6", {
+    'value_type'    => Variant[Stdlib::IP::Address::V6, Boolean],
+    'default_value' => false,
+  })
+  $a = concat([], $anycastv4, $anycastv6, $keepalivedipv4, $keepalivedipv6)
+  $addresses = delete($a, false)
+
+  # Construct a suitable hash with bind information
+  $bind = $addresses.reduce({}) | $memo, $address | {
+    $memo + {"${address}:${port}" => []}
+  }
+
+  # Collect lists of servers behind this frontend. Used by the haproxy
+  # management script 'haproxy-manage.sh'
+  profile::services::haproxy::tools::collect { "bk_${name}": }
+
+  # Define some suitable default options
+  $ftbaseoptions = {
+    'default_backend' => "bk_${name}",
+  }
+  $bkbaseoptions = {
+    'balance' => 'source',
+    'option'  => [
+      'tcplog',
+    ],
+  }
+
+  # Define a haproxy frontend+backend pair
+  haproxy::frontend { "ft_${name}":
+    bind    => $bind,
+    mode    => 'tcp',
+    options => deep_merge($ftbaseoptions, $ftoptions),
+  }
+  haproxy::backend { "bk_${name}":
+    mode    => 'tcp',
+    options => deep_merge($bkbaseoptions + $bkoptions),
+  }
+}

--- a/manifests/services/haproxy/frontend.pp
+++ b/manifests/services/haproxy/frontend.pp
@@ -55,6 +55,6 @@ define profile::services::haproxy::frontend (
   }
   haproxy::backend { "bk_${name}":
     mode    => 'tcp',
-    options => deep_merge($bkbaseoptions + $bkoptions),
+    options => deep_merge($bkbaseoptions, $bkoptions),
   }
 }

--- a/manifests/services/haproxy/frontend.pp
+++ b/manifests/services/haproxy/frontend.pp
@@ -29,11 +29,6 @@ define profile::services::haproxy::frontend (
   $a = concat([], $anycastv4, $anycastv6, $keepalivedipv4, $keepalivedipv6)
   $addresses = delete($a, false)
 
-  # Only allow encryption of when in HTTP mode.
-  if($certfile and $mode == 'tcp') {
-    fail('Haproxy cannot encrypt non-SSL sockets')
-  }
-
   # Determine suitable options for http-mode. Addin headers to indicate that the
   # traffic was indeed encrypted in front of the loadbalancer, if that was the
   # case.
@@ -46,7 +41,11 @@ define profile::services::haproxy::frontend (
       $proto = { 'reqadd' => 'X-Forwarded-Proto:\ http' }
     }
   } else {
-    $sslpar = []
+    if($certfile) {
+      $sslpar = ['ssl', 'crt', $certfile]
+    } else {
+      $sslpar = []
+    }
     $proto = {}
   }
 

--- a/manifests/services/haproxy/web.pp
+++ b/manifests/services/haproxy/web.pp
@@ -62,7 +62,7 @@ class profile::services::haproxy::web {
   }
 
   $base_bind = $addresses.map | $address | {
-    "${address}:80" => []
+    {"${address}:80" => []}
   }
 
   if($certificate) {
@@ -75,7 +75,7 @@ class profile::services::haproxy::web {
     }
 
     $ssl_bind = $addresses.map | $address | {
-      "${address}:443" => ['ssl', 'crt', $certfile]
+      {"${address}:443" => ['ssl', 'crt', $certfile]}
     }
   } else {
     $redirect = {}

--- a/manifests/services/haproxy/web.pp
+++ b/manifests/services/haproxy/web.pp
@@ -61,8 +61,8 @@ class profile::services::haproxy::web {
     'reqadd'      => 'X-Forwarded-Proto:\ https if { ssl_fc }',
   }
 
-  $base_bind = $addresses.map | $address | {
-    {"${address}:80" => []}
+  $base_bind = $addresses.reduce({}) | $memo, $address | {
+    $memo + {"${address}:80" => []}
   }
 
   if($certificate) {
@@ -74,8 +74,8 @@ class profile::services::haproxy::web {
       $redirect = { 'redirect' => 'scheme https code 301 if !{ ssl_fc }' }
     }
 
-    $ssl_bind = $addresses.map | $address | {
-      {"${address}:443" => ['ssl', 'crt', $certfile]}
+    $ssl_bind = $addresses.reduce({}) | $memo, $address | {
+      $memo + {"${address}:443" => ['ssl', 'crt', $certfile]}
     }
   } else {
     $redirect = {}

--- a/manifests/services/haproxy/web.pp
+++ b/manifests/services/haproxy/web.pp
@@ -11,7 +11,7 @@ class profile::services::haproxy::web {
     'value_type'    => Variant[Stdlib::IP::Address::V4, Boolean],
     'default_value' => false,
   })
-  $anycastv6 = lookup("profile::anycast::${profile}::ipv4", {
+  $anycastv6 = lookup("profile::anycast::${profile}::ipv6", {
     'value_type'    => Variant[Stdlib::IP::Address::V6, Boolean],
     'default_value' => false,
   })

--- a/manifests/services/haproxy/web.pp
+++ b/manifests/services/haproxy/web.pp
@@ -35,11 +35,11 @@ class profile::services::haproxy::web {
   $certificate = lookup("profile::haproxy::${profile}::webcert", {
     'default_value' => false,
   })
-  $certfile = hiera("profile::haproxy::${profile}::webcert::certfile", {
+  $certfile = lookup("profile::haproxy::${profile}::webcert::certfile", {
     'default_value' => '/etc/ssl/private/haproxy.pem',
     'value_type'    => String,
   })
-  $nossl = hiera("profile::haproxy::${profile}::nossl", {
+  $nossl = lookup("profile::haproxy::${profile}::nossl", {
     'value_type'    => Variant[Boolean, String],
     'default_value' => false,
   })

--- a/manifests/services/keepalived/haproxy/management.pp
+++ b/manifests/services/keepalived/haproxy/management.pp
@@ -1,33 +1,45 @@
 # Keepalived config for management haproxy servers
 class profile::services::keepalived::haproxy::management {
-  require ::profile::services::keepalived
+  $v4_ip = lookup('profile::haproxy::management::ipv4', {
+    'value_type' => Variant[String, Boolean],
+    'default_value' => false,
+  })
+  $v6_ip = lookup('profile::haproxy::management::ipv6', {
+    'value_type' => Variant[String, Boolean],
+    'default_value' => false,
+  })
 
-  $v4_ip = hiera('profile::haproxy::management::ipv4')
-  $v4_id = hiera('profile::haproxy::management::ipv4::id')
-  $v4_priority = hiera('profile::haproxy::management::ipv4::priority')
-  $v6_ip = hiera('profile::haproxy::management::ipv6', false)
-  $v6_id = hiera('profile::haproxy::management::ipv6::id', false)
-  $v6_priority = hiera('profile::haproxy::management::ipv6::priority', false)
+  if ( $v4_ip or $v6_ip ) {
+    require ::profile::services::keepalived
 
-  $vrrp_password = hiera('profile::keepalived::vrrp_password')
-  $management_if = hiera('profile::interfaces::management')
+    $vrrp_password = lookup('profile::keepalived::vrrp_password')
+    $management_if = lookup('profile::interfaces::management')
 
-  keepalived::vrrp::script { 'check_haproxy':
-    script => '/usr/bin/killall -0 haproxy',
+    keepalived::vrrp::script { 'check_haproxy':
+      script => '/usr/bin/killall -0 haproxy',
+    }
   }
 
-  keepalived::vrrp::instance { 'management-haproxy-v4':
-    interface         => $management_if,
-    state             => 'BACKUP',
-    virtual_router_id => $v4_id,
-    priority          => $v4_priority,
-    auth_type         => 'PASS',
-    auth_pass         => $vrrp_password,
-    virtual_ipaddress => ["${v4_ip}/32"],
-    track_script      => 'check_haproxy',
+  if ( $v4_ip ) {
+    $v4_id = lookup('profile::haproxy::management::ipv4::id')
+    $v4_priority = lookup('profile::haproxy::management::ipv4::priority')
+
+    keepalived::vrrp::instance { 'management-haproxy-v4':
+      interface         => $management_if,
+      state             => 'BACKUP',
+      virtual_router_id => $v4_id,
+      priority          => $v4_priority,
+      auth_type         => 'PASS',
+      auth_pass         => $vrrp_password,
+      virtual_ipaddress => ["${v4_ip}/32"],
+      track_script      => 'check_haproxy',
+    }
   }
 
   if ( $v6_ip ) {
+    $v6_id = lookup('profile::haproxy::management::ipv6::id')
+    $v6_priority = lookup('profile::haproxy::management::ipv6::priority')
+
     keepalived::vrrp::instance { 'management-haproxy-v6':
       interface         => $management_if,
       state             => 'BACKUP',

--- a/manifests/services/keepalived/haproxy/management.pp
+++ b/manifests/services/keepalived/haproxy/management.pp
@@ -49,6 +49,6 @@ class profile::services::keepalived::haproxy::management {
       auth_pass         => $vrrp_password,
       virtual_ipaddress => ["${v6_ip}/64"],
       track_script      => 'check_haproxy',
-    } 
+    }
   }
 }

--- a/manifests/services/keepalived/haproxy/services.pp
+++ b/manifests/services/keepalived/haproxy/services.pp
@@ -13,7 +13,7 @@ class profile::services::keepalived::haproxy::services {
     require ::profile::services::keepalived
 
     $vrrp_password = lookup('profile::keepalived::vrrp_password')
-    $management_if = lookup('profile::interfaces::management')
+    $services_if = lookup('profile::interfaces::management')
 
     keepalived::vrrp::script { 'check_haproxy':
       script => '/usr/bin/killall -0 haproxy',

--- a/manifests/services/keepalived/haproxy/services.pp
+++ b/manifests/services/keepalived/haproxy/services.pp
@@ -1,33 +1,45 @@
 # Keepalived config for public haproxy servers
 class profile::services::keepalived::haproxy::services {
-  require ::profile::services::keepalived
+  $v4_ip = lookup('profile::haproxy::management::ipv4', {
+    'value_type' => Variant[String, Boolean],
+    'default_value' => false,
+  })
+  $v6_ip = lookup('profile::haproxy::management::ipv6', {
+    'value_type' => Variant[String, Boolean],
+    'default_value' => false,
+  })
 
-  $v4_ip = hiera('profile::haproxy::services::ipv4')
-  $v4_id = hiera('profile::haproxy::services::ipv4::id')
-  $v4_priority = hiera('profile::haproxy::services::ipv4::priority')
-  $v6_ip = hiera('profile::haproxy::services::ipv6', false)
-  $v6_id = hiera('profile::haproxy::services::ipv6::id', false)
-  $v6_priority = hiera('profile::haproxy::services::ipv6::priority', false)
+  if ( $v4_ip or $v6_ip ) {
+    require ::profile::services::keepalived
 
-  $vrrp_password = hiera('profile::keepalived::vrrp_password')
-  $services_if = hiera('profile::interfaces::services')
+    $vrrp_password = lookup('profile::keepalived::vrrp_password')
+    $management_if = lookup('profile::interfaces::management')
 
-  keepalived::vrrp::script { 'check_haproxy':
-    script => '/usr/bin/killall -0 haproxy',
+    keepalived::vrrp::script { 'check_haproxy':
+      script => '/usr/bin/killall -0 haproxy',
+    }
   }
 
-  keepalived::vrrp::instance { 'services-haproxy-v4':
-    interface         => $services_if,
-    state             => 'BACKUP',
-    virtual_router_id => $v4_id,
-    priority          => $v4_priority,
-    auth_type         => 'PASS',
-    auth_pass         => $vrrp_password,
-    virtual_ipaddress => ["${v4_ip}/32"],
-    track_script      => 'check_haproxy',
+  if ( $v4_ip ) {
+    $v4_id = lookup('profile::haproxy::management::ipv4::id')
+    $v4_priority = lookup('profile::haproxy::management::ipv4::priority')
+
+    keepalived::vrrp::instance { 'services-haproxy-v4':
+      interface         => $services_if,
+      state             => 'BACKUP',
+      virtual_router_id => $v4_id,
+      priority          => $v4_priority,
+      auth_type         => 'PASS',
+      auth_pass         => $vrrp_password,
+      virtual_ipaddress => ["${v4_ip}/32"],
+      track_script      => 'check_haproxy',
+    }
   }
 
   if ( $v6_ip ) {
+    $v6_id = lookup('profile::haproxy::management::ipv6::id')
+    $v6_priority = lookup('profile::haproxy::management::ipv6::priority')
+
     keepalived::vrrp::instance { 'services-haproxy-v6':
       interface         => $services_if,
       state             => 'BACKUP',

--- a/manifests/services/keepalived/haproxy/services.pp
+++ b/manifests/services/keepalived/haproxy/services.pp
@@ -1,10 +1,10 @@
 # Keepalived config for public haproxy servers
 class profile::services::keepalived::haproxy::services {
-  $v4_ip = lookup('profile::haproxy::management::ipv4', {
+  $v4_ip = lookup('profile::haproxy::services::ipv4', {
     'value_type' => Variant[String, Boolean],
     'default_value' => false,
   })
-  $v6_ip = lookup('profile::haproxy::management::ipv6', {
+  $v6_ip = lookup('profile::haproxy::services::ipv6', {
     'value_type' => Variant[String, Boolean],
     'default_value' => false,
   })
@@ -13,7 +13,7 @@ class profile::services::keepalived::haproxy::services {
     require ::profile::services::keepalived
 
     $vrrp_password = lookup('profile::keepalived::vrrp_password')
-    $services_if = lookup('profile::interfaces::management')
+    $services_if = lookup('profile::interfaces::services')
 
     keepalived::vrrp::script { 'check_haproxy':
       script => '/usr/bin/killall -0 haproxy',
@@ -21,8 +21,8 @@ class profile::services::keepalived::haproxy::services {
   }
 
   if ( $v4_ip ) {
-    $v4_id = lookup('profile::haproxy::management::ipv4::id')
-    $v4_priority = lookup('profile::haproxy::management::ipv4::priority')
+    $v4_id = lookup('profile::haproxy::services::ipv4::id')
+    $v4_priority = lookup('profile::haproxy::services::ipv4::priority')
 
     keepalived::vrrp::instance { 'services-haproxy-v4':
       interface         => $services_if,
@@ -37,8 +37,8 @@ class profile::services::keepalived::haproxy::services {
   }
 
   if ( $v6_ip ) {
-    $v6_id = lookup('profile::haproxy::management::ipv6::id')
-    $v6_priority = lookup('profile::haproxy::management::ipv6::priority')
+    $v6_id = lookup('profile::haproxy::services::ipv6::id')
+    $v6_priority = lookup('profile::haproxy::services::ipv6::priority')
 
     keepalived::vrrp::instance { 'services-haproxy-v6':
       interface         => $services_if,

--- a/manifests/services/memcache/firewall.pp
+++ b/manifests/services/memcache/firewall.pp
@@ -1,53 +1,16 @@
 # Firewall rules for memcached
 class profile::services::memcache::firewall {
-  require ::profile::baseconfig::firewall
-
-  $infrav4 = lookup('profile::networking::infrastructure::ipv4::prefixes', {
-    'value_type' => Array[Stdlib::IP::Address::V4::CIDR],
-    'merge'      => 'unique',
-  })
-  $infrav6 = lookup('profile::networking::infrastructure::ipv6::prefixes', {
-    'value_type'    => Array[Stdlib::IP::Address::V6::CIDR],
-    'merge'         => 'unique',
-    'default_value' => [],
-  })
-
   $memcached_port = lookup('profile::memcache::port', {
     'default_value' => 11211,
     'value_type'    => Integer,
   })
 
-  $infrav4.each | $net | {
-    firewall { "500 accept incoming memcached tcp from ${net}":
-      source => $net,
-      proto  => 'tcp',
-      dport  => $memcached_port,
-      action => 'accept',
-    }
-
-    firewall { "500 accept incoming memcached udp from ${net}":
-      source => $net,
-      proto  => 'udp',
-      dport  => $memcached_port,
-      action => 'accept',
-    }
+  ::profile::baseconfig::firewall::service::infra { 'TCP Memcache':
+    protocol => 'tcp',
+    port     => $memcached_port,
   }
-
-  $infrav6.each | $net | {
-    firewall { "500 accept incoming memcached tcp from ${net}":
-      source   => $net,
-      proto    => 'tcp',
-      dport    => $memcached_port,
-      action   => 'accept',
-      provider => 'ip6tables',
-    }
-
-    firewall { "500 accept incoming memcached udp from ${net}":
-      source   => $net,
-      proto    => 'udp',
-      dport    => $memcached_port,
-      action   => 'accept',
-      provider => 'ip6tables',
-    }
+  ::profile::baseconfig::firewall::service::infra { 'UDP Memcache':
+    protocol => 'udp',
+    port     => $memcached_port,
   }
 }

--- a/manifests/services/mysql/firewall/balancer.pp
+++ b/manifests/services/mysql/firewall/balancer.pp
@@ -1,26 +1,33 @@
 #Configures the firewall for the mysql loadbalancers
 class profile::services::mysql::firewall::balancer {
-  require ::firewall
+  require ::profile::baseconfig::firewall
 
-  $managementv4 = hiera('profile::networks::management::ipv4::prefix', false)
-  $managementv6 = hiera('profile::networks::management::ipv6::prefix', false)
+  $infrav4 = lookup('profile::networking::infrastructure::ipv4::prefixes', {
+    'value_type' => Array[Stdlib::IP::Address::V4::CIDR],
+    'merge'      => 'unique',
+  })
+  $infrav6 = lookup('profile::networking::infrastructure::ipv6::prefixes', {
+    'value_type'    => Array[Stdlib::IP::Address::V6::CIDR],
+    'merge'         => 'unique',
+    'default_value' => [],
+  })
 
-  if($managementv4) {
-    firewall { '071 Accept incoming MySQL requests':
-      source => $managementv4,
+  $infrav4.each | $net | {
+    firewall { "071 Accept incoming MySQL requests from ${net}":
+      source => $net,
       proto  => 'tcp',
       dport  => 3306,
       action => 'accept',
     }
   }
 
-  if($managementv6) {
-    firewall { '071 ipv6 Accept incoming MySQL requests':
-      source   => $managementv6,
+  $infrav6.each | $net | {
+    firewall { "071 Accept incoming MySQL requests from ${net}":
+      source   => $net,
       proto    => 'tcp',
       dport    => 3306,
       action   => 'accept',
-      provider => 'ip6tables', 
+      provider => 'ip6tables',
     }
   }
 }

--- a/manifests/services/mysql/firewall/balancer.pp
+++ b/manifests/services/mysql/firewall/balancer.pp
@@ -1,33 +1,7 @@
 #Configures the firewall for the mysql loadbalancers
 class profile::services::mysql::firewall::balancer {
-  require ::profile::baseconfig::firewall
-
-  $infrav4 = lookup('profile::networking::infrastructure::ipv4::prefixes', {
-    'value_type' => Array[Stdlib::IP::Address::V4::CIDR],
-    'merge'      => 'unique',
-  })
-  $infrav6 = lookup('profile::networking::infrastructure::ipv6::prefixes', {
-    'value_type'    => Array[Stdlib::IP::Address::V6::CIDR],
-    'merge'         => 'unique',
-    'default_value' => [],
-  })
-
-  $infrav4.each | $net | {
-    firewall { "071 Accept incoming MySQL requests from ${net}":
-      source => $net,
-      proto  => 'tcp',
-      dport  => 3306,
-      action => 'accept',
-    }
-  }
-
-  $infrav6.each | $net | {
-    firewall { "071 Accept incoming MySQL requests from ${net}":
-      source   => $net,
-      proto    => 'tcp',
-      dport    => 3306,
-      action   => 'accept',
-      provider => 'ip6tables',
-    }
+  ::profile::baseconfig::firewall::service::infra { 'MYSQL':
+    protocol => 'tcp',
+    port     => 3306,
   }
 }

--- a/manifests/services/mysql/firewall/server.pp
+++ b/manifests/services/mysql/firewall/server.pp
@@ -1,63 +1,15 @@
 #Configures the firewall for the mysql servers
 class profile::services::mysql::firewall::server {
-  require ::profile::baseconfig::firewall
-
-  $infrav4 = lookup('profile::networking::infrastructure::ipv4::prefixes', {
-    'value_type' => Array[Stdlib::IP::Address::V4::CIDR],
-    'merge'      => 'unique',
-  })
-  $infrav6 = lookup('profile::networking::infrastructure::ipv6::prefixes', {
-    'value_type'    => Array[Stdlib::IP::Address::V6::CIDR],
-    'merge'         => 'unique',
-    'default_value' => [],
-  })
-
-  $infrav4.each | $net | {
-    firewall { "070 Accept incoming MySQL requests from ${net}":
-      proto  => 'tcp',
-      dport  => 3306,
-      action => 'accept',
-      source => $net,
-    }
-
-    firewall { "071 Accept incoming MySQL galera from ${net}":
-      proto  => 'tcp',
-      dport  => [4567, 4568, 4444, 9000],
-      action => 'accept',
-      source => $net,
-    }
-
-    firewall { "072 Accept incoming MySQL galera from ${net}":
-      proto  => 'udp',
-      dport  => 4567,
-      action => 'accept',
-      source => $net,
-    }
+  ::profile::baseconfig::firewall::service::infra { 'MYSQL':
+    protocol => 'tcp',
+    port     => 3306,
   }
-
-  $infrav6.each | $net | {
-    firewall { "070 Accept incoming MySQL requests from ${net}":
-      proto    => 'tcp',
-      dport    => 3306,
-      action   => 'accept',
-      source   => $net,
-      provider => 'ip6tables',
-    }
-
-    firewall { "071 Accept incoming MySQL galera from ${net}":
-      proto    => 'tcp',
-      dport    => [4567, 4568, 4444, 9000],
-      action   => 'accept',
-      source   => $net,
-      provider => 'ip6tables',
-    }
-
-    firewall { "072 Accept incoming MySQL galera from ${net}":
-      proto    => 'udp',
-      dport    => 4567,
-      action   => 'accept',
-      source   => $net,
-      provider => 'ip6tables',
-    }
+  ::profile::baseconfig::firewall::service::infra { 'MYSQL TCP Replication':
+    protocol => 'tcp',
+    port     => [4567, 4568, 4444, 9000],
+  }
+  ::profile::baseconfig::firewall::service::infra { 'MYSQL UDP Replication':
+    protocol => 'udp',
+    port     => 4567,
   }
 }

--- a/manifests/services/mysql/firewall/server.pp
+++ b/manifests/services/mysql/firewall/server.pp
@@ -1,55 +1,63 @@
 #Configures the firewall for the mysql servers
 class profile::services::mysql::firewall::server {
-  require ::firewall
+  require ::profile::baseconfig::firewall
 
-  $management_net = hiera('profile::networks::management::ipv4::prefix')
-  $extra_net = hiera('profile::networks::management::ipv4::prefix::extra',
-      false)
-  $management_if = hiera('profile::interfaces::management')
-  $autoip = $facts['networking']['interfaces'][$management_if]['ip']
-  $ip = hiera("profile::interfaces::${management_if}::address", $autoip)
+  $infrav4 = lookup('profile::networking::infrastructure::ipv4::prefixes', {
+    'value_type' => Array[Stdlib::IP::Address::V4::CIDR],
+    'merge'      => 'unique',
+  })
+  $infrav6 = lookup('profile::networking::infrastructure::ipv6::prefixes', {
+    'value_type'    => Array[Stdlib::IP::Address::V6::CIDR],
+    'merge'         => 'unique',
+    'default_value' => [],
+  })
 
-  # We only accept incoming requests from the management-net, as all other
-  # requests should come in trough the loadbalancers.
-  firewall { '070 Accept incoming MySQL requests':
-    proto       => 'tcp',
-    dport       => 3306,
-    action      => 'accept',
-    source      => $management_net,
-    destination => $ip,
-  }
-
-  firewall { '071 Accept incoming MySQL galera':
-    proto       => 'tcp',
-    dport       => [4567, 4568, 4444, 9000],
-    action      => 'accept',
-    source      => $management_net,
-    destination => $ip,
-  }
-
-  firewall { '072 Accept incoming MySQL galera':
-    proto       => 'udp',
-    dport       => 4567,
-    action      => 'accept',
-    source      => $management_net,
-    destination => $ip,
-  }
-
-  if($extra_net) {
-    firewall { '073 Accept incoming MySQL galera':
-      proto       => 'tcp',
-      dport       => [4567, 4568, 4444, 9000],
-      action      => 'accept',
-      source      => $extra_net,
-      destination => $ip,
+  $infrav4.each | $net | {
+    firewall { "070 Accept incoming MySQL requests from ${net}":
+      proto  => 'tcp',
+      dport  => 3306,
+      action => 'accept',
+      source => $net,
     }
 
-    firewall { '074 Accept incoming MySQL galera':
-      proto       => 'udp',
-      dport       => 4567,
-      action      => 'accept',
-      source      => $extra_net,
-      destination => $ip,
+    firewall { "071 Accept incoming MySQL galera from ${net}":
+      proto  => 'tcp',
+      dport  => [4567, 4568, 4444, 9000],
+      action => 'accept',
+      source => $net,
+    }
+
+    firewall { "072 Accept incoming MySQL galera from ${net}":
+      proto  => 'udp',
+      dport  => 4567,
+      action => 'accept',
+      source => $net,
+    }
+  }
+
+  $infrav6.each | $net | {
+    firewall { "070 Accept incoming MySQL requests from ${net}":
+      proto    => 'tcp',
+      dport    => 3306,
+      action   => 'accept',
+      source   => $net,
+      provider => 'ip6tables',
+    }
+
+    firewall { "071 Accept incoming MySQL galera from ${net}":
+      proto    => 'tcp',
+      dport    => [4567, 4568, 4444, 9000],
+      action   => 'accept',
+      source   => $net,
+      provider => 'ip6tables',
+    }
+
+    firewall { "072 Accept incoming MySQL galera from ${net}":
+      proto    => 'udp',
+      dport    => 4567,
+      action   => 'accept',
+      source   => $net,
+      provider => 'ip6tables',
     }
   }
 }

--- a/manifests/services/mysql/haproxy/frontend.pp
+++ b/manifests/services/mysql/haproxy/frontend.pp
@@ -1,42 +1,9 @@
 # Configures the haproxy in frontend for the mysql cluster
 class profile::services::mysql::haproxy::frontend {
-  require ::profile::services::haproxy
   include ::profile::services::mysql::firewall::balancer
 
-  $ipv4 = hiera('profile::haproxy::management::ipv4')
-  $ipv6 = hiera('profile::haproxy::management::ipv6', false)
-
-  profile::services::haproxy::tools::collect { 'bk_mysqlcluster': }
-
-  $ft_options = {
-    'default_backend' => 'bk_mysqlcluster',
-  }
-
-  if($ipv6) {
-    haproxy::frontend { 'ft_mysqlcluster':
-      bind    => {
-        "${ipv4}:3306" => [],
-        "${ipv6}:3306" => [],
-      },
-      mode    => 'tcp',
-      options => $ft_options,
-    }
-  } else {
-    haproxy::frontend { 'ft_mysqlcluster':
-      ipaddress => $ipv4,
-      ports     => '3306',
-      mode      => 'tcp',
-      options   => $ft_options,
-    }
-  }
-
-  haproxy::backend { 'bk_mysqlcluster':
-    mode    => 'tcp',
-    options => {
-      'balance' => 'source',
-      'option'  => [
-        'tcplog',
-      ],
-    },
+  ::profile::services::haproxy::frontend { 'mysqlcluster':
+    profile => 'management',
+    port    => 3306,
   }
 }

--- a/manifests/services/postgresql/firewall.pp
+++ b/manifests/services/postgresql/firewall.pp
@@ -1,39 +1,7 @@
 #Configures the firewall for the postgres servers
 class profile::services::postgresql::firewall {
-  require ::firewall
-
-  $management_net = hiera('profile::networks::management::ipv4::prefix')
-  $management_netv6 = hiera('profile::networks::management::ipv6::prefix', false)
-  $management_if = hiera('profile::interfaces::management')
-  $autoip = $facts['networking']['interfaces'][$management_if]['ip']
-  $ip = hiera("profile::interfaces::${management_if}::address", $autoip)
-  $postgresql_ipv4 = hiera('profile::postgres::ipv4')
-  $postgresql_ipv6 = hiera('profile::postgres::ipv6', false)
-
-  # We limit incoming requests to the management-network as it is only puppetdb
-  # servers which needs postgres, and these live on this network.
-  firewall { '070 Accept incoming postgres requests':
-    proto       => 'tcp',
-    dport       => 5432,
-    action      => 'accept',
-    source      => $management_net,
-    destination => $ip,
-  }
-  firewall { '071 Accept incoming postgres requests':
-    proto       => 'tcp',
-    dport       => 5432,
-    action      => 'accept',
-    source      => $management_net,
-    destination => $postgresql_ipv4,
-  }
-  if($postgresql_ipv6) {
-    firewall { '071 ipv6 Accept incoming postgres requests':
-      proto       => 'tcp',
-      dport       => 5432,
-      action      => 'accept',
-      source      => $management_netv6,
-      destination => $postgresql_ipv6,
-      provider    => 'ip6tables',
-    }
+  ::profile::baseconfig::firewall::service::infra { 'Postgres':
+    protocol => 'tcp',
+    port     => 5432,
   }
 }

--- a/manifests/services/puppet/db/firewall.pp
+++ b/manifests/services/puppet/db/firewall.pp
@@ -1,33 +1,7 @@
 # Configures the firewall for puppetmasters. 
 class profile::services::puppet::db::firewall {
-  require ::firewall
-
-  $infrav4 = lookup('profile::networking::infrastructure::ipv4::prefixes', {
-    'value_type' => Array[Stdlib::IP::Address::V4::CIDR],
-    'merge'      => 'unique',
-  })
-  $infrav6 = lookup('profile::networking::infrastructure::ipv6::prefixes', {
-    'value_type'    => Array[Stdlib::IP::Address::V6::CIDR],
-    'merge'         => 'unique',
-    'default_value' => [],
-  })
-
-  $infrav4.each | $net | {
-    firewall { "051 Accept incoming puppetdb from ${net}":
-      proto  => 'tcp',
-      dport  => 8081,
-      action => 'accept',
-      source => $net,
-    }
-  }
-
-  $infrav6.each | $net | {
-    firewall { "051 Accept incoming puppetdb from ${net}":
-      proto    => 'tcp',
-      dport    => 8081,
-      action   => 'accept',
-      source   => $net,
-      provider => 'ip6tables',
-    }
+  ::profile::baseconfig::firewall::service::infra { 'PuppetDB':
+    protocol => 'tcp',
+    port     => 8081,
   }
 }

--- a/manifests/services/puppet/db/firewall.pp
+++ b/manifests/services/puppet/db/firewall.pp
@@ -6,7 +6,7 @@ class profile::services::puppet::db::firewall {
     'value_type' => Array[Stdlib::IP::Address::V4::CIDR],
     'merge'      => 'unique',
   })
-  $infrav6 = lookup('profile::networking::infrastructure::ipv4::prefixes', {
+  $infrav6 = lookup('profile::networking::infrastructure::ipv6::prefixes', {
     'value_type' => Array[Stdlib::IP::Address::V6::CIDR],
     'merge'      => 'unique',
   })

--- a/manifests/services/puppet/db/firewall.pp
+++ b/manifests/services/puppet/db/firewall.pp
@@ -7,8 +7,9 @@ class profile::services::puppet::db::firewall {
     'merge'      => 'unique',
   })
   $infrav6 = lookup('profile::networking::infrastructure::ipv6::prefixes', {
-    'value_type' => Array[Stdlib::IP::Address::V6::CIDR],
-    'merge'      => 'unique',
+    'value_type'    => Array[Stdlib::IP::Address::V6::CIDR],
+    'merge'         => 'unique',
+    'default_value' => [],
   })
 
   $infrav4.each | $net | {

--- a/manifests/services/puppet/db/haproxy/frontend.pp
+++ b/manifests/services/puppet/db/haproxy/frontend.pp
@@ -1,41 +1,9 @@
 # Configures the haproxy in frontend for the puppetdb service
 class profile::services::puppet::db::haproxy::frontend {
-  require ::profile::services::haproxy
   include ::profile::services::puppet::db::firewall
 
-  $ipv4 = hiera('profile::haproxy::management::ipv4')
-  $ipv6 = hiera('profile::haproxy::management::ipv6', false)
-
-  profile::services::haproxy::tools::collect { 'bk_puppetdb': }
-
-  $ft_options = {
-    'default_backend' => 'bk_puppetdb',
-  }
-
-  if($ipv6) {
-    haproxy::frontend { 'ft_puppetdb':
-      bind    => {
-        "${ipv4}:8081" => [],
-        "${ipv6}:8081" => [],
-      },
-      mode    => 'tcp',
-      options => $ft_options,
-    }
-  } else {
-    haproxy::frontend { 'ft_puppetdb':
-      ipaddress => $ipv4,
-      ports     => '8081',
-      mode      => 'tcp',
-      options   => $ft_options,
-    }
-  }
-  haproxy::backend { 'bk_puppetdb':
-    mode    => 'tcp',
-    options => {
-      'balance' => 'roundrobin',
-      'option'  => [
-        'tcplog',
-      ],
-    },
+  ::profile::services::haproxy::frontend { 'puppetserver':
+    profile => 'management',
+    port    => 8140,
   }
 }

--- a/manifests/services/puppet/db/haproxy/frontend.pp
+++ b/manifests/services/puppet/db/haproxy/frontend.pp
@@ -2,8 +2,8 @@
 class profile::services::puppet::db::haproxy::frontend {
   include ::profile::services::puppet::db::firewall
 
-  ::profile::services::haproxy::frontend { 'puppetserver':
+  ::profile::services::haproxy::frontend { 'puppetdb':
     profile => 'management',
-    port    => 8140,
+    port    => 8081,
   }
 }

--- a/manifests/services/puppet/server/firewall.pp
+++ b/manifests/services/puppet/server/firewall.pp
@@ -6,7 +6,7 @@ class profile::services::puppet::server::firewall {
     'value_type' => Array[Stdlib::IP::Address::V4::CIDR],
     'merge'      => 'unique',
   })
-  $infrav6 = lookup('profile::networking::infrastructure::ipv4::prefixes', {
+  $infrav6 = lookup('profile::networking::infrastructure::ipv6::prefixes', {
     'value_type' => Array[Stdlib::IP::Address::V6::CIDR],
     'merge'      => 'unique',
   })

--- a/manifests/services/puppet/server/firewall.pp
+++ b/manifests/services/puppet/server/firewall.pp
@@ -2,25 +2,30 @@
 class profile::services::puppet::server::firewall {
   require ::firewall
 
-  $managementv4 = hiera('profile::networks::management::ipv4::prefix', false)
-  $managementv6 = hiera('profile::networks::management::ipv6::prefix', false)
+  $infrav4 = lookup('profile::networking::infrastructure::ipv4::prefixes', {
+    'value_type' => Array[Stdlib::IP::Address::V4::CIDR],
+    'merge'      => 'unique',
+  })
+  $infrav6 = lookup('profile::networking::infrastructure::ipv4::prefixes', {
+    'value_type' => Array[Stdlib::IP::Address::V6::CIDR],
+    'merge'      => 'unique',
+  })
 
-  if($managementv4) {
-    firewall { '050 Accept incoming puppet':
+  $infrav4.each | $net | {
+    firewall { "050 Accept incoming puppet from ${net}":
       proto  => 'tcp',
       dport  => 8140,
       action => 'accept',
-      source => $managementv4,
+      source => $net,
     }
   }
-
-  if($managementv6) {
-    firewall { '050 ipv6 Accept incoming puppet':
+  $infrav6.each | $net | {
+    firewall { "050 Accept incoming puppet from ${net}":
       proto    => 'tcp',
       dport    => 8140,
       action   => 'accept',
+      source   => $net,
       provider => 'ip6tables',
-      source   => $managementv6,
     }
   }
 }

--- a/manifests/services/puppet/server/firewall.pp
+++ b/manifests/services/puppet/server/firewall.pp
@@ -1,32 +1,7 @@
 # Configures the firewall for puppetmasters. 
 class profile::services::puppet::server::firewall {
-  require ::firewall
-
-  $infrav4 = lookup('profile::networking::infrastructure::ipv4::prefixes', {
-    'value_type' => Array[Stdlib::IP::Address::V4::CIDR],
-    'merge'      => 'unique',
-  })
-  $infrav6 = lookup('profile::networking::infrastructure::ipv6::prefixes', {
-    'value_type'    => Array[Stdlib::IP::Address::V6::CIDR],
-    'merge'         => 'unique',
-    'default_value' => [],
-  })
-
-  $infrav4.each | $net | {
-    firewall { "050 Accept incoming puppet from ${net}":
-      proto  => 'tcp',
-      dport  => 8140,
-      action => 'accept',
-      source => $net,
-    }
-  }
-  $infrav6.each | $net | {
-    firewall { "050 Accept incoming puppet from ${net}":
-      proto    => 'tcp',
-      dport    => 8140,
-      action   => 'accept',
-      source   => $net,
-      provider => 'ip6tables',
-    }
+  ::profile::baseconfig::firewall::service::infra { 'Puppetmaster':
+    protocol => 'tcp',
+    port     => 8140,
   }
 }

--- a/manifests/services/puppet/server/firewall.pp
+++ b/manifests/services/puppet/server/firewall.pp
@@ -7,8 +7,9 @@ class profile::services::puppet::server::firewall {
     'merge'      => 'unique',
   })
   $infrav6 = lookup('profile::networking::infrastructure::ipv6::prefixes', {
-    'value_type' => Array[Stdlib::IP::Address::V6::CIDR],
-    'merge'      => 'unique',
+    'value_type'    => Array[Stdlib::IP::Address::V6::CIDR],
+    'merge'         => 'unique',
+    'default_value' => [],
   })
 
   $infrav4.each | $net | {

--- a/manifests/services/puppet/server/haproxy/frontend.pp
+++ b/manifests/services/puppet/server/haproxy/frontend.pp
@@ -1,41 +1,9 @@
 # Configures the haproxy in frontend for the puppetmasters 
 class profile::services::puppet::server::haproxy::frontend {
-  require ::profile::services::haproxy
   include ::profile::services::puppet::server::firewall
 
-  $ipv4 = hiera('profile::haproxy::management::ipv4')
-  $ipv6 = hiera('profile::haproxy::management::ipv6', false)
-
-  profile::services::haproxy::tools::collect { 'bk_puppetserver': }
-
-  $ft_options = {
-    'default_backend' => 'bk_puppetserver',
-  }
-
-  if($ipv6) {
-    haproxy::frontend { 'ft_puppetserver':
-      bind    => {
-        "${ipv4}:8140" => [],
-        "${ipv6}:8140" => [],
-      },
-      mode    => 'tcp',
-      options => $ft_options,
-    }
-  } else {
-    haproxy::frontend { 'ft_puppetserver':
-      ipaddress => $ipv4,
-      ports     => '8140',
-      mode      => 'tcp',
-      options   => $ft_options,
-    }
-  }
-  haproxy::backend { 'bk_puppetserver':
-    mode    => 'tcp',
-    options => {
-      'balance' => 'roundrobin',
-      'option'  => [
-        'tcplog',
-      ],
-    },
+  ::profile::services::haproxy::frontend { 'puppetserver':
+    profile => 'management',
+    port    => 8140,
   }
 }

--- a/manifests/services/rabbitmq/firewall.pp
+++ b/manifests/services/rabbitmq/firewall.pp
@@ -1,46 +1,11 @@
 # Configure firewall for rabbitmq servers
 class profile::services::rabbitmq::firewall {
-  require ::profile::baseconfig::firewall
-
-  $infrav4 = lookup('profile::networking::infrastructure::ipv4::prefixes', {
-    'value_type' => Array[Stdlib::IP::Address::V4::CIDR],
-    'merge'      => 'unique',
-  })
-  $infrav6 = lookup('profile::networking::infrastructure::ipv6::prefixes', {
-    'value_type'    => Array[Stdlib::IP::Address::V6::CIDR],
-    'merge'         => 'unique',
-    'default_value' => [],
-  })
-
-  $infrav4.each | $net | {
-    firewall { "500 accept incoming rabbitmq from ${net}":
-      source => $net,
-      proto  => 'tcp',
-      dport  => 5672,
-      action => 'accept',
-    }
-    firewall { "502 accept incoming rabbitmqcluster from ${net}":
-      source => $net,
-      proto  => 'tcp',
-      dport  => [4369, 25672],
-      action => 'accept',
-    }
+  ::profile::baseconfig::firewall::service::infra { 'RabbitMQ':
+    protocol => 'tcp',
+    port     => 5672,
   }
-
-  $infrav6.each | $net | {
-    firewall { "500 accept incoming rabbitmq from ${net}":
-      source   => $net,
-      proto    => 'tcp',
-      dport    => 5672,
-      action   => 'accept',
-      provider => 'ip6tables',
-    }
-    firewall { "502 accept incoming rabbitmqcluster from ${net}":
-      source   => $net,
-      proto    => 'tcp',
-      dport    => [4369, 25672],
-      action   => 'accept',
-      provider => 'ip6tables',
-    }
+  ::profile::baseconfig::firewall::service::infra { 'RabbitMQ-Clustering':
+    protocol => 'tcp',
+    port     => [4369, 25672],
   }
 }

--- a/manifests/services/redis/firewall.pp
+++ b/manifests/services/redis/firewall.pp
@@ -1,33 +1,7 @@
 # Configure firewall for redis servers
 class profile::services::redis::firewall {
-  require ::profile::baseconfig::firewall
-
-  $infrav4 = lookup('profile::networking::infrastructure::ipv4::prefixes', {
-    'value_type' => Array[Stdlib::IP::Address::V4::CIDR],
-    'merge'      => 'unique',
-  })
-  $infrav6 = lookup('profile::networking::infrastructure::ipv6::prefixes', {
-    'value_type'    => Array[Stdlib::IP::Address::V6::CIDR],
-    'merge'         => 'unique',
-    'default_value' => [],
-  })
-
-  $infrav4.each | $net | {
-    firewall { "050 accept redis-server from ${net}":
-      proto  => 'tcp',
-      dport  => 6379,
-      action => 'accept',
-      source => $net,
-    }
-  }
-
-  $infrav6.each | $net | {
-    firewall { "050 accept redis-server from ${net}":
-      proto    => 'tcp',
-      dport    => 6379,
-      action   => 'accept',
-      source   => $net,
-      provider => 'ip6tables',
-    }
+  ::profile::baseconfig::firewall::service::infra { 'Redis':
+    protocol => 'tcp',
+    port     => 6379,
   }
 }

--- a/manifests/services/redis/haproxy.pp
+++ b/manifests/services/redis/haproxy.pp
@@ -4,7 +4,7 @@ class profile::services::redis::haproxy {
 
   $redisauth = lookup('profile::redis::masterauth')
 
-  ::profile::services::haproxy::frontend { 'mysqlcluster':
+  ::profile::services::haproxy::frontend { 'redis':
     profile   => 'management',
     port      => 6379,
     ftoptions => {

--- a/manifests/services/redis/haproxy.pp
+++ b/manifests/services/redis/haproxy.pp
@@ -10,6 +10,7 @@ class profile::services::redis::haproxy {
     ftoptions => {
       'option' => [
         'clitcpka',
+        'tcplog',
         'srvtcpka',
       ],
     },

--- a/manifests/services/redis/haproxy.pp
+++ b/manifests/services/redis/haproxy.pp
@@ -1,47 +1,22 @@
 # Haproxy config for redis
-
 class profile::services::redis::haproxy {
-  require ::profile::services::haproxy
   include ::profile::services::redis::firewall
 
-  $ipv4 = hiera('profile::haproxy::management::ipv4')
-  $ipv6 = hiera('profile::haproxy::management::ipv6', false)
-  $redisauth = hiera('profile::redis::masterauth')
+  $redisauth = lookup('profile::redis::masterauth')
 
-  profile::services::haproxy::tools::collect { 'bk_redis': }
-
-  $ft_options = {
-    'default_backend' => 'bk_redis',
-    'option'          => [
-      'clitcpka',
-      'srvtcpka',
-    ],
-  }
-
-  if($ipv6) {
-    haproxy::frontend { 'ft_redis':
-      bind    => {
-        "${ipv4}:6379" => [],
-        "${ipv6}:6379" => [],
-      },
-      mode    => 'tcp',
-      options => $ft_options,
-    }
-  } else {
-    haproxy::frontend { 'ft_redis':
-      ipaddress => $ipv4,
-      ports     => '6379',
-      mode      => 'tcp',
-      options   => $ft_options,
-    }
-  }
-
-  haproxy::backend { 'bk_redis':
-    options => {
+  ::profile::services::haproxy::frontend { 'mysqlcluster':
+    profile   => 'management',
+    port      => 6379,
+    ftoptions => {
+      'option' => [
+        'clitcpka',
+        'srvtcpka',
+      ],
+    },
+    bkoptions => {
       'option'    => [
         'log-health-checks',
         'tcp-check',
-        'tcplog',
       ],
       'tcp-check' => [
         'connect',

--- a/manifests/services/tftp/firewall.pp
+++ b/manifests/services/tftp/firewall.pp
@@ -2,10 +2,8 @@
 class profile::services::tftp::firewall {
   # TFTP also uses higher-numbered ports for the actual data-transfer; but this
   # is handled by the defult allow ESTABLISHED incoming rule from baseconfig.
-  firewall { '400 accept incoming TFTP':
-    proto  => 'udp',
-    dport  => [69],
-    action => 'accept',
+  ::profile::baseconfig::firewall::service::global { 'TFTP':
+    protocol => 'udp',
+    port     => 69,
   }
-  require ::profile::baseconfig::firewall 
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "ntnusky-profile",
-  "version": "1.2.0",
+  "version": "1.6.0",
   "author": "NTNU IIK",
   "summary": "Installs, configures, and manages services in our openstack environment.",
   "license": "",
@@ -13,7 +13,7 @@
     { "name":"example42/network","version_requirement":">= 3.3.8 < 4.0.0" },
     { "name":"inkblot/ipcalc","version_requirement":">= 2.2.0 < 3.0.0" },
     { "name":"puppetlabs/concat","version_requirement":">= 1.2.5 < 5.0.0" },
-    { "name":"puppetlabs/stdlib","version_requirement":">= 4.24.0 < 5.0.0" },
+    { "name":"puppetlabs/stdlib","version_requirement":">= 4.25.0 < 6.0.0" },
     { "name":"puppetlabs/inifile","version_requirement":">= 1.5.0 < 2.0.0" },
     { "name":"ntnusky/ntnuopenstack","version_requirement":">= 1.0.0 < 5.0.0" },
     { "name":"puppet/rabbitmq","version_requirement":">= 8.2.2 < 9.0.0" }

--- a/templates/bird/bgp.epp
+++ b/templates/bird/bgp.epp
@@ -1,0 +1,11 @@
+<%- | String $filtername,
+      Integer $aslocal,
+      Integer $asremote,
+      String $neighbourIP,
+| -%>
+protocol bgp {
+  export filter <%= $filtername %>;
+  local as <%= $aslocal %>;
+  neighbor <%= $neighbourIP %> as <%= $asremote %>;
+}
+

--- a/templates/bird/filter.epp
+++ b/templates/bird/filter.epp
@@ -1,0 +1,8 @@
+<%- | Array $prefixes,
+      String $name,
+| -%>
+filter <%= $name %> {
+<% $prefixes.each |$prefix| { -%>
+  if net = <%= $prefix %> then accept;
+<% } -%>
+}

--- a/templates/bird/general.epp
+++ b/templates/bird/general.epp
@@ -1,0 +1,17 @@
+<%- | Integer $kernel_scan = 20,
+      Integer $device_scan = 60,
+| -%>
+log syslog all;
+
+protocol direct {
+  interface "lo";
+}
+
+protocol kernel {
+  persist;
+  scan time <%= $kernel_scan %>;
+}
+
+protocol device {
+  scan time <%= $device_scan %>;
+}

--- a/templates/interface.ipv6.epp
+++ b/templates/interface.ipv6.epp
@@ -1,0 +1,9 @@
+<%- | String $interface,
+      String $v6address,
+      Integer $v6mask,
+| -%>
+# The interface <%= $interface %> have a static IPv6 address
+iface <%= $interface %> inet6 static
+    address <%= $v6address %>
+    netmask <%= $v6mask %>
+


### PR DESCRIPTION
### Changes

Allow setting static IPv6 address on an interface.

Add defines to help configure firewalls.
 - `profile::baseconfig::firewall::service::global`
 - `profile::baseconfig::firewall::service::infra`
 - `profile::baseconfig::firewall::service::management`

Made all firewall-configuration use these defines.

Add the possibility to install and configure the bird routing daemon

Add nessecary packages to mount ceph volumes through rbd-nbd map.

Add a define to configure a generic haproxy frontend
 - `profile::services::haproxy::frontend`

Made all haproxy-frontend use this define.

Made keepalived in front of haproxy optional
 - If the key `profile::haproxy::management::ipv(4|6)` is set, keepalived will be
   installed and configured.

Add option to configure an anycast IP in front of haproxy; announcing this IP
through BIRD.
 - If the key `profile::bird::anycast::ipv(4|6)::address` is set, bird will be
   configured.

### HIERA

New MANDATORY hiera-keys to configure firewalls for IPv4:
 - `profile::networking::infrastructure::ipv4::prefixes` - A list over IPv4 prefixes,
                     which describes the infrastructure network(s)

New OPTIONAL hiera-keys to configure firewalls for IPv6:
 - `profile::networking::infrastructure::ipv6::prefixes` - A list over IPv6 prefixes,
                     which describes the infrastructure network(s)

New OPTIONAL hiera-keys to set a manual IPv6 address on an interface:
 - `profile::interfaces::${name}::ipv6::address`
 - `profile::interfaces::${name}::ipv6::mask`

New OPTIONAL keys to make haproxy listen to the anycast IP's:
 - `profile::anycast::management::ipv4`
 - `profile::anycast::management::ipv6`
 - `profile::anycast::services::ipv4`
 - `profile::anycast::services::ipv6`

The previosly mandatory hiera-keys to make haproxy listen to keepalived IP's is
now OPTIONAL:
 - `profile::haproxy::management::ipv4`
 - `profile::haproxy::management::ipv6`
 - `profile::haproxy::services::ipv4`
 - `profile::haproxy::services::ipv6`

New OPTIONAL hiera-keys to control the announcement of the anycast IPv4 address.
 - profile:`:bird:`:router::id - The BGP router ID. If not set, the management IP
                               will be used.
 - `profile::bird::anycast::ipv4::address` - An IPv4 address to be announced
 - `profile::bird::anycast::ipv4::bgp::as::local` - Local BGP AS number
 - `profile::bird::anycast::ipv4::bgp::as::remote` - Remote BGP AS number
 - `profile::bird::anycast::ipv4::bgp::peer` - BGP peer address
 - `profile::bird::anycast::ipv6::address` - An IPv6 address to be announced
 - `profile::bird::anycast::ipv6::bgp::as::local` - Local BGP AS number
 - `profile::bird::anycast::ipv6::bgp::as::remote` - Remote BGP AS number
 - `profile::bird::anycast::ipv6::bgp::peer` - BGP peer address