### PR TITLE
Only include domain name in a DHCP pool if it's explicitly enabled.

### DIFF
--- a/manifests/services/dhcp/pool.pp
+++ b/manifests/services/dhcp/pool.pp
@@ -1,16 +1,32 @@
 # Creates DHCP pool based on data from hiera
 define profile::services::dhcp::pool {
-  $id = hiera("profile::networks::${name}::ipv4::id")
-  $domain = hiera("profile::networks::${name}::domain")
-  $mask = hiera("profile::networks::${name}::ipv4::mask")
-  $gateway = hiera("profile::networks::${name}::ipv4::gateway", '')
-  $range = hiera("profile::networks::${name}::ipv4::dynamicrange", '')
+  $id = lookup("profile::networks::${name}::ipv4::id")
+  $domain = lookup("profile::networks::${name}::domain")
+  $mask = lookup("profile::networks::${name}::ipv4::mask")
+  $gateway = lookup("profile::networks::${name}::ipv4::gateway", {
+    'default_value' => '',
+    'value_type'    => Variant[Stdlib::IP::Address::V4, String],
+  })
+  $range = lookup("profile::networks::${name}::ipv4::dynamicrange", {
+    'default_value' => '',
+    'value_type'    => Variant[Array[String], String],
+  })
+  $include_name = lookup("profile::networks::${name}::dhcp::include_name", {
+    'default_value' => false,
+    'value_type'    => Boolean,
+  })
+
+  if($include_name) {
+    $domain_real = $domain
+  } else {
+    $domain_real = ''
+  }
 
   ::dhcp::pool { "${name}":
     network     => $id,
     mask        => $mask,
     range       => $range,
     gateway     => $gateway,
-    domain_name => $domain,
+    domain_name => $domain_real,
   }
 }


### PR DESCRIPTION
From now on ``option domain-name`` will only be configured in a DHCP pool if the pool has its ``profile::networks::${name}::dhcp::include_name`` hiera keys set to ``true``. 

This is mainly done because servers with multiple interfaces will get a fairly random DNS search suffix order when it receives multiple domain-names, and that can potentially break (i.e) live migration for compute nodes.