### PR TITLE
Ceph n - Munin plugins

### DIFF
--- a/files/ceph/insightsKillSwitch.sh
+++ b/files/ceph/insightsKillSwitch.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# This is a 'strikk & binders' script to disable ceph insights if the /var disk
+# gets too full. Basicly a kill-switch to avoid the ceph-mon's being stopped by
+# a full drive.
+
+# When /var is more full than this; disable insights
+threshold=75
+
+# Determine how full /var is.
+current=$(/bin/df -h /var/ | /usr/bin/tail -n +2 | \
+	    /usr/bin/awk '{ print $5 }' | /usr/bin/tr -d '%')
+
+# If var is too full:
+if [[ $threshold -le $current ]]; then
+  # If the insights module is enabled
+  if /usr/bin/ceph mgr module ls | /usr/bin/jq -C '.["enabled_modules"]' | \
+        /bin/grep -q 'insights'; then
+    # Disable the insights module
+    /usr/bin/ceph mgr module disable insights
+  fi
+fi

--- a/files/muninplugins/ceph_activity_iops
+++ b/files/muninplugins/ceph_activity_iops
@@ -19,10 +19,12 @@ if [[ $1 == "config" ]]; then
     name=${name//-/_}
 
     echo "${name}write.label $realname"
-    echo "${name}write.type COUNTER"
+    echo "${name}write.type DERIVE"
+    echo "${name}write.min 0"
     echo "${name}write.graph no"
     echo "${name}read.label $realname"
-    echo "${name}read.type COUNTER"
+    echo "${name}read.type DERIVE"
+    echo "${name}read.min 0"
     echo "${name}read.negative ${name}write"
   done
   rm $tmpfile

--- a/files/muninplugins/ceph_activity_iops
+++ b/files/muninplugins/ceph_activity_iops
@@ -2,7 +2,7 @@
 set -e
 
 tmpfile=$(mktemp)
-wget http://127.0.0.1:7000/health_data -O $tmpfile &> /dev/null
+ceph insights > $tmpfile
 
 if [[ $1 == "config" ]]; then
   echo "graph_title CEPH Activity - IOPS"

--- a/files/muninplugins/ceph_activity_iops
+++ b/files/muninplugins/ceph_activity_iops
@@ -14,14 +14,14 @@ if [[ $1 == "config" ]]; then
   echo "graph_width 550"
   
   for pool in $(jq -c '.["df"]["pools"][]' $tmpfile); do
-    name=$(echo $pool | jq -r '.["name"]')
-    name=${name//./_}
+    realname=$(echo $pool | jq -r '.["name"]')
+    name=${realname//./_}
     name=${name//-/_}
 
-    echo "${name}write.label $name"
+    echo "${name}write.label $realname"
     echo "${name}write.type COUNTER"
     echo "${name}write.graph no"
-    echo "${name}read.label $name"
+    echo "${name}read.label $realname"
     echo "${name}read.type COUNTER"
     echo "${name}read.negative ${name}write"
   done

--- a/files/muninplugins/ceph_activity_traffic
+++ b/files/muninplugins/ceph_activity_traffic
@@ -14,14 +14,14 @@ if [[ $1 == "config" ]]; then
   echo "graph_width 550"
   
   for pool in $(jq -c '.["df"]["pools"][]' $tmpfile); do
-    name=$(echo $pool | jq -r '.["name"]')
-    name=${name//./_}
+    realname=$(echo $pool | jq -r '.["name"]')
+    name=${realname//./_}
     name=${name//-/_}
 
-    echo "${name}write.label $name"
+    echo "${name}write.label $realname"
     echo "${name}write.type COUNTER"
     echo "${name}write.graph no"
-    echo "${name}read.label $name"
+    echo "${name}read.label $realname"
     echo "${name}read.type COUNTER"
     echo "${name}read.negative ${name}write"
   done

--- a/files/muninplugins/ceph_activity_traffic
+++ b/files/muninplugins/ceph_activity_traffic
@@ -5,12 +5,12 @@ tmpfile=$(mktemp)
 ceph insights > $tmpfile
 
 if [[ $1 == "config" ]]; then
-  echo "graph_title CEPH Activity - Bytes read/written"
+  echo "graph_title CEPH Activity - Bits read/written"
   echo "graph_category ceph"
   echo "graph_vlabel bits/sec read(+)/write(-)"
   echo "graph_args -l 0"
   echo "graph_scale yes"
-  echo "graph_info Read and write operations to ceph-pools"
+  echo "graph_info Read and write traffic to ceph-pools"
   echo "graph_width 550"
   
   for pool in $(jq -c '.["df"]["pools"][]' $tmpfile); do
@@ -19,10 +19,12 @@ if [[ $1 == "config" ]]; then
     name=${name//-/_}
 
     echo "${name}write.label $realname"
-    echo "${name}write.type COUNTER"
+    echo "${name}write.type DERIVE"
+    echo "${name}write.min 0"
     echo "${name}write.graph no"
     echo "${name}read.label $realname"
-    echo "${name}read.type COUNTER"
+    echo "${name}read.type DERIVE"
+    echo "${name}read.min 0"
     echo "${name}read.negative ${name}write"
   done
   rm $tmpfile

--- a/files/muninplugins/ceph_activity_traffic
+++ b/files/muninplugins/ceph_activity_traffic
@@ -2,7 +2,7 @@
 set -e
 
 tmpfile=$(mktemp)
-wget http://127.0.0.1:7000/health_data -O $tmpfile &> /dev/null
+ceph insights > $tmpfile
 
 if [[ $1 == "config" ]]; then
   echo "graph_title CEPH Activity - Bytes read/written"

--- a/files/muninplugins/ceph_objects
+++ b/files/muninplugins/ceph_objects
@@ -20,6 +20,7 @@ if [[ $1 == "config" ]]; then
     echo ${name}.label $(echo $pool | jq -r '.["name"]')
     echo ${name}.info Objects in the $(echo $pool | jq -r '.["name"]') pool.
   done
+  rm $tmpfile
   exit 0
 fi
 

--- a/files/muninplugins/ceph_osd
+++ b/files/muninplugins/ceph_osd
@@ -25,12 +25,12 @@ while read -r osd; do
   up=$(echo $osd | jq '.["up"]')
   in=$(echo $osd | jq '.["in"]')
 
-  ((osds++))
+  osds=$((osds + 1))
   if [ $up -eq 1 ]; then
-    ((ups++))
+    ups=$((ups + 1))
   fi
   if [ $in -eq 1 ]; then
-    ((ins++))
+    ins=$((ins + 1))
   fi
 done < <(ceph insights | jq -c '.["osd_dump"]["osds"][]') 
 

--- a/files/muninplugins/ceph_osd
+++ b/files/muninplugins/ceph_osd
@@ -1,49 +1,39 @@
-#!/bin/sh
-
-: << =cut
-
-=head1 NAME
-
-ceph_osd - Shows ceph OSD states (total configured, up and in)
-
-=head1 AUTHOR
-
-Mate Gabri <mate@gabri.hu>
-
-=head1 LICENSE
-
-GPLv2
-
-=head1 MAGICK MARKERS
-
- #%# family=auto
- #%# capabilities=autoconf
-
-=cut
-
-if [ "$1" = "autoconf" ]; then
-	echo yes
-	exit 0
-fi
-
+#!/bin/bash
+set -e
 
 if [ "$1" = "config" ]; then
 	
 	echo 'graph_title CEPH OSDs'
 	echo 'graph_category ceph'
-	echo 'graph_vlabel nr'
+	echo 'graph_vlabel number'
 	echo 'graph_info CEPH OSD up/down status'
 	echo 'graph_scale no'
 	echo 'graph_args --base 1000 -l 0'
 
-	echo "osds.label OSDs"
+	echo "osds.label Total"
 	echo "up.label Up"
 	echo "in.label In"
-	echo "in.draw AREA"
 
 	exit 0
 fi
 
-echo "osds.value $(ceph -s | grep osd | awk '{ print $2 }')"
-echo "up.value $(ceph -s | grep osd | awk '{ print $4 }')"
-echo "in.value $(ceph -s | grep osd | awk '{ print $6 }')"
+osds=0
+ups=0
+ins=0
+
+while read -r osd; do
+  up=$(echo $osd | jq '.["up"]')
+  in=$(echo $osd | jq '.["in"]')
+
+  ((osds++))
+  if [ $up -eq 1 ]; then
+    ((ups++))
+  fi
+  if [ $in -eq 1 ]; then
+    ((ins++))
+  fi
+done < <(ceph insights | jq -c '.["osd_dump"]["osds"][]') 
+
+echo "osds.value $osds" 
+echo "up.value $ups" 
+echo "in.value $ins" 

--- a/files/muninplugins/ceph_storage
+++ b/files/muninplugins/ceph_storage
@@ -5,17 +5,17 @@ tmpfile=$(mktemp)
 ceph insights > $tmpfile
 
 if [[ $1 == "config" ]]; then
-  echo "graph_title CEPH Objects"
+  echo "graph_title CEPH Storage"
   echo "graph_category ceph"
-  echo "graph_vlabel Objects"
+  echo "graph_vlabel Bytes"
   echo "graph_args -l 0"
   echo "graph_scale yes"
-  echo "graph_info The number of objects in each ceph pool"
+  echo "graph_info The number of bytes in each ceph pool"
   
   for pool in $(jq -c '.["df"]["pools"][]' $tmpfile); do
     name=$(echo $pool | jq -r '.["name"]')
-    name=${name//-/_}
     name=${name//./_}
+    name=${name//-/_}
     
     echo ${name}.label $(echo $pool | jq -r '.["name"]')
     echo ${name}.info Objects in the $(echo $pool | jq -r '.["name"]') pool.
@@ -28,7 +28,7 @@ for pool in $(jq -c '.["df"]["pools"][]' $tmpfile); do
   name=${name//./_}
   name=${name//-/_}
   
-  echo ${name}.value $(echo $pool | jq '.["stats"]["objects"]')
+  echo ${name}.value $(echo $pool | jq '.["stats"]["bytes_used"]')
 done
 
 rm $tmpfile

--- a/files/muninplugins/ceph_storage
+++ b/files/muninplugins/ceph_storage
@@ -20,6 +20,7 @@ if [[ $1 == "config" ]]; then
     echo ${name}.label $(echo $pool | jq -r '.["name"]')
     echo ${name}.info Objects in the $(echo $pool | jq -r '.["name"]') pool.
   done
+  rm $tmpfile
   exit 0
 fi
 

--- a/files/muninplugins/ceph_total
+++ b/files/muninplugins/ceph_total
@@ -8,7 +8,7 @@ if [[ $1 == "config" ]]; then
   echo 'graph_info CEPH cluster capacity'
   echo 'graph_args -l 0'
   echo "capacity.label Capacity"
-  echo "free.label Capacity"
+  echo "free.label Free"
   echo "data.label Data stored"
 
   exit 0

--- a/files/muninplugins/ceph_total
+++ b/files/muninplugins/ceph_total
@@ -1,57 +1,24 @@
 #!/bin/bash
+set -e
 
-: << =cut
-
-=head1 NAME
-
-ceph_total - Shows ceph total storage capacity and used raw space
-
-=head1 CONFIGURATION
-
-=head1 AUTHOR
-
-Eigil Obrestad <eigil-git@obrestad.org>
-
-=head1 LICENSE
-
-Public domain
-
-=head1 CHANGELOG
-
-=cut
-
-if [ "$1" = "autoconf" ]; then
-  echo yes
-  exit 0
-fi
-
-if [ "$1" = "config" ]; then
+if [[ $1 == "config" ]]; then
   echo 'graph_title CEPH total capacity'
   echo 'graph_category ceph'
   echo 'graph_vlabel Bytes'
   echo 'graph_info CEPH cluster capacity'
   echo 'graph_args -l 0'
   echo "capacity.label Capacity"
-  echo "used.label Raw used"
-  echo "used.draw AREA"
+  echo "free.label Capacity"
+  echo "data.label Data stored"
 
   exit 0
 fi
 
-declare -A factors
-factors[B]=1
-factors[KiB]=1024
-factors[MiB]=1048576
-factors[GiB]=1073741824
-factors[TiB]=1099511627776
-factors[PiB]=1125899906842624
+tmpfile=$(mktemp)
+ceph insights > $tmpfile
 
-usage=$(ceph df | grep GLOBAL -A2 | tail -n 1)
+echo "capacity.value $(cat $tmpfile | jq '.["df"]["stats"]["total_bytes"]')"
+echo "free.value $(cat $tmpfile | jq '.["df"]["stats"]["total_avail_bytes"]')"
+echo "data.value $(cat $tmpfile | jq '.["df"]["stats"]["total_used_raw_bytes"]')"
 
-if [[ $usage =~ ([0-9\.]+)([KMGTP]?i?B)\ +([0-9\.]+)([KMGTP]?i?B)\ +([0-9\.]+)([KMGTP]?i?B) ]]; then
-  echo capacity.value $(echo "${BASH_REMATCH[1]} * ${factors[${BASH_REMATCH[2]}]}" | bc)
-  echo used.value $(echo "${BASH_REMATCH[5]} * ${factors[${BASH_REMATCH[6]}]}" | bc)
-else
-  echo "capacity.value U"
-  echo "used.value U"
-fi
+rm $tmpfile

--- a/manifests/ceph/monitor.pp
+++ b/manifests/ceph/monitor.pp
@@ -42,5 +42,19 @@ class profile::ceph::monitor {
     before  => Anchor['profile::ceph::monitor::end']
   }
 
+  file { '/usr/local/sbin/insightsKillSwitch.sh':
+    ensure => present,
+    owner  => 'root',
+    group  => 'root',
+    mode   => '0755',
+    source => 'puppet:///modules/profile/ceph/insightsKillSwitch.sh',
+  }
+
+  cron { 'Ceph insights killswitch':
+    command => '/usr/local/sbin/insightsKillSwitch.sh',
+    user    => 'root',
+    minute  => '*',
+  }
+
   anchor{'profile::ceph::monitor::end':}
 }

--- a/manifests/monitoring/munin/plugin/ceph.pp
+++ b/manifests/monitoring/munin/plugin/ceph.pp
@@ -19,18 +19,10 @@ class profile::monitoring::munin::plugin::ceph {
     source => 'puppet:///modules/profile/muninplugins/ceph_osd',
     config => ['user root'],
   }
-  munin::plugin { 'ceph_usage':
+  munin::plugin { 'ceph_storage':
     ensure => present,
-    source => 'puppet:///modules/profile/muninplugins/ceph_usage',
+    source => 'puppet:///modules/profile/muninplugins/ceph_storage',
     config => ['user root'],
-  }
-
-  # Enable the ceph dashboard, as the ceph_activity_* plugins get its data from
-  # there.
-  $jq = '/usr/bin/jq \'.["enabled_modules"]\''
-  exec { 'Enable ceph dashboards':
-    command => '/usr/bin/ceph mgr module enable dashboard',
-    unless  => "/usr/bin/ceph mgr module ls | ${jq} | /bin/grep -c 'dashboard'",
   }
 
   # These ceph activity-plugins should replace the ceph-collector(s).sh scripts


### PR DESCRIPTION
This PR upgrades the munin-plugins monitoring the ceph cluster. Some plugins change their backend data; so it might make sense to delete the RRDfiles for ceph-activity graphs on the munin-nodes so that the files can be recreated. This is to avoid spikes in the graphs.

The graphs need the ceph-insight module to be enabled to work. This module is enabled cluster-wide with 'ceph mgr module enable insights'. The insights-module fills /var in an error-situation, and a cron-job is thus supplied to disable the module if var is more than 75% full. Var should be 20-ish GB large, at least, to accomodate for some growth.