### PR TITLE
Change the logic connecting libvirt networks to openvswitches.

### DIFF
--- a/files/vswitch/addPatch.sh
+++ b/files/vswitch/addPatch.sh
@@ -72,7 +72,7 @@ fi
 if [[ $exists -eq 1 && \
     $(ovs-vsctl get interface $srcPort options:peer) != "\"$dstPort\"" && \
     $(ovs-vsctl get interface $srcPort options:peer) != "$dstPort" ]]; then
-  echo "The port $srcPort is does not have the peer $dstPort configured"
+  echo "The port $srcPort does not have the peer $dstPort configured"
   STATUS=$MISSING
   if [[ $verify -eq 0 ]]; then
     ovs-vsctl set interface $srcPort options:peer=$dstPort
@@ -114,7 +114,7 @@ fi
 if [[ $exists -eq 1 && \
     $(ovs-vsctl get interface $dstPort options:peer) != "\"$srcPort\"" && \
     $(ovs-vsctl get interface $dstPort options:peer) != "$srcPort" ]]; then
-  echo "The port $dstPort is does not have the peer $srcPort configured"
+  echo "The port $dstPort does not have the peer $srcPort configured"
   STATUS=$MISSING
   if [[ $verify -eq 0 ]]; then
     ovs-vsctl set interface $dstPort options:peer=$srcPort

--- a/files/vswitch/addPatch.sh
+++ b/files/vswitch/addPatch.sh
@@ -112,7 +112,8 @@ if [[ $exists -eq 1 && $(ovs-vsctl get interface $dstPort type) != "patch" ]]; t
 fi
 # Verify that the port is connected to the correct peer
 if [[ $exists -eq 1 && \
-    $(ovs-vsctl get interface $dstPort options:peer) != "\"$srcPort\"" ]]; then
+    $(ovs-vsctl get interface $dstPort options:peer) != "\"$srcPort\"" && \
+    $(ovs-vsctl get interface $dstPort options:peer) != "$srcPort" ]]; then
   echo "The port $dstPort is does not have the peer $srcPort configured"
   STATUS=$MISSING
   if [[ $verify -eq 0 ]]; then

--- a/files/vswitch/addPatch.sh
+++ b/files/vswitch/addPatch.sh
@@ -70,7 +70,8 @@ if [[ $exists -eq 1 && $(ovs-vsctl get interface $srcPort type) != "patch" ]]; t
 fi
 # Verify that the port is connected to the correct peer
 if [[ $exists -eq 1 && \
-    $(ovs-vsctl get interface $srcPort options:peer) != "\"$dstPort\"" ]]; then
+    $(ovs-vsctl get interface $srcPort options:peer) != "\"$dstPort\"" && \
+    $(ovs-vsctl get interface $srcPort options:peer) != "$dstPort" ]]; then
   echo "The port $srcPort is does not have the peer $dstPort configured"
   STATUS=$MISSING
   if [[ $verify -eq 0 ]]; then

--- a/manifests/infrastructure/ovs/patch/simple.pp
+++ b/manifests/infrastructure/ovs/patch/simple.pp
@@ -1,0 +1,17 @@
+# This define creates a patch between two openvswitch switches.
+define profile::infrastructure::ovs::patch::simple (
+  String $source_bridge,
+  String $destination_bridge
+) {
+  require ::profile::infrastructure::ovs::script::patch
+
+  $scriptArgs = "${source_bridge} ${destination_bridge}"
+  exec { "/usr/local/bin/addPatch.sh ${scriptArgs}":
+    unless  => "/usr/local/bin/addPatch.sh ${scriptArgs} --verify",
+    path    => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+    require => [
+      Profile::Infrastructure::Ovs::Bridge[$source_bridge],
+      Profile::Infrastructure::Ovs::Bridge[$destination_bridge],
+    ],
+  }
+}

--- a/manifests/services/libvirt/networks.pp
+++ b/manifests/services/libvirt/networks.pp
@@ -1,36 +1,54 @@
-# Configure networks for libvirt
+# Configure networks for libvirt. Connects libvirt networks to openvswitch
+# switches according to hiera: 
+#
+# profile::kvm::networks:
+#   <networkname>:
+#     bridge: '<vswitch-bridge>'
+#   <networkname>:
+#     bridge: '<vswitch-bridge>'
+#     vlan: <vlanID>
+#
 class profile::services::libvirt::networks {
   require ::vswitch::ovs
 
-  $networks = hiera('profile::networks', {})
-  $networks.each | $network |  {
-    # Linux interfaces is max 16 chars long (br-<12 chars>\0)
-    $bridge_name = $network[0,12]
-    $enable_multicast = hiera("profile::networks::${network}::enable_multicast", true)
-    $vlanid = hiera("profile::networks::${network}::vlanid")
-    $physical_if = hiera("profile::kvm::interfaces::${network}", false)
-    if ( $physical_if ) {
-      vs_bridge { "br-${bridge_name}":
-        ensure => present,
+  # The proposed way of configuring networks
+  $kvm_networks = lookup('profile::kvm::networks', {
+    'default_value' => {},
+    'merge'         => 'deep',
+    'value_type'    => Hash[String, Hash],
+  }
+
+  $kvm_networks.each | $netname, $data | {
+    $shortname = $netname[0,12]
+    $bridge = $data['bridge']
+
+    profile::infrastructure::ovs::bridge { "br-${shortname}": }
+
+    if('vlanid' in $data) {
+      profile::infrastructure::ovs::patch::vlan { 
+          "patch br-${shortname} to ${bridge}":
+        source_bridge      => $bridge,
+        source_vlan        => $data['vlanid'],
+        destination_bridge => "br-${shortname}",
       }
-      $n = "${network}-${vlanid}-br"
-      ::profile::infrastructure::ovs::patch { $n :
-        physical_if => $physical_if,
-        vlan_id     => $vlanid,
-        ovs_bridge  => "br-${bridge_name}",
-        require     => Vs_bridge["br-${bridge_name}"],
+    } else {
+      profile::infrastructure::ovs::patch::simple { 
+          "patch br-${shortname} to ${bridge}":
+        source_bridge      => $bridge,
+        destination_bridge => "br-${shortname}",
       }
-      ::libvirt::network { $network:
-        ensure                => 'running',
-        autostart             => true,
-        forward_mode          => 'bridge',
-        forward_interfaces    => [ "br-${bridge_name}", ],
-        trust_guest_rxfilters => $enable_multicast,
-      }
-      sysctl::value { "net.ipv6.conf.br-${bridge_name}.autoconf":
-        value   => '0',
-        require => Vs_bridge["br-${bridge_name}"],
-      }
+    }
+
+    ::libvirt::network { $network:
+      ensure                => 'running',
+      autostart             => true,
+      forward_mode          => 'bridge',
+      forward_interfaces    => [ "br-${shortname}", ],
+      trust_guest_rxfilters => true, 
+    }
+    sysctl::value { "net.ipv6.conf.br-${shortname}.autoconf":
+      value   => '0',
+      require => Profile::Infrastructure::Ovs::Bridge["br-${shortname}"],
     }
   }
 }

--- a/manifests/services/libvirt/networks.pp
+++ b/manifests/services/libvirt/networks.pp
@@ -16,9 +16,9 @@ class profile::services::libvirt::networks {
     'default_value' => {},
     'merge'         => 'deep',
     'value_type'    => Hash[String, Hash],
-  }
+  })
 
-  $kvm_networks.each | $netname, $data | {
+  $kvm_networks.each | String $netname, Hash $data | {
     $shortname = $netname[0,12]
     $bridge = $data['bridge']
 

--- a/manifests/services/libvirt/networks.pp
+++ b/manifests/services/libvirt/networks.pp
@@ -25,26 +25,26 @@ class profile::services::libvirt::networks {
     profile::infrastructure::ovs::bridge { "br-${shortname}": }
 
     if('vlanid' in $data) {
-      profile::infrastructure::ovs::patch::vlan { 
+      profile::infrastructure::ovs::patch::vlan {
           "patch br-${shortname} to ${bridge}":
         source_bridge      => $bridge,
         source_vlan        => $data['vlanid'],
         destination_bridge => "br-${shortname}",
       }
     } else {
-      profile::infrastructure::ovs::patch::simple { 
+      profile::infrastructure::ovs::patch::simple {
           "patch br-${shortname} to ${bridge}":
         source_bridge      => $bridge,
         destination_bridge => "br-${shortname}",
       }
     }
 
-    ::libvirt::network { $network:
+    ::libvirt::network { "${netname}":
       ensure                => 'running',
       autostart             => true,
       forward_mode          => 'bridge',
       forward_interfaces    => [ "br-${shortname}", ],
-      trust_guest_rxfilters => true, 
+      trust_guest_rxfilters => true,
     }
     sysctl::value { "net.ipv6.conf.br-${shortname}.autoconf":
       value   => '0',


### PR DESCRIPTION
Now a libvirt network is defined and connected to an openvswitch with the following information in hiera:

```
profile::kvm::networks:
  <networkname>:
    bridge: '<vswitch bridge>'
  <networkname>:
    bridge: '<vswitch bridge>'
    vlan: <VLAN ID>
```

To get the old structure where a dedicated interface is used for all libvirt
stuff to work you would need the following in hiera:

```
profile::baseconfig::network::interfaces:
  eno2:
    ipv4:
      method: 'manual'
profile::baseconfig::network::bridges:
  br-vlan-eno2:
    external:
      type: 'interface'
      name: 'eno2'
profile::kvm::networks:
  infra:
    bridge: 'br-vlan-eno2'
    vlanid: 42
  storage:
    bridge: 'br-vlan-eno2'
    vlanid: 1337
```