### PR TITLE
Bonding

### DIFF
--- a/manifests/baseconfig/network/netplan.pp
+++ b/manifests/baseconfig/network/netplan.pp
@@ -11,7 +11,7 @@ class profile::baseconfig::network::netplan (Hash $nics) {
     $nic = $n[0]
     $table_id = $nics[$nic]['tableid']
     $mtu   = { 'mtu'   => $nics[$nic]['mtu'] }
-    if ( $nic =~ /^(lo|infra)/ ) {
+    if ( $nic =~ /^(lo|infra)/ or $nics[$nic]['nomatch']) {
       $match = {}
     } else {
       $mac = $::facts['networking']['interfaces'][$nic]['mac']

--- a/manifests/baseconfig/networking.pp
+++ b/manifests/baseconfig/networking.pp
@@ -31,15 +31,27 @@ class profile::baseconfig::networking {
 
     # If the bridge should have an external connection
     if($configuration['external']) {
+      # The connection might be a bond consisting of multiple physical
+      # interfaces:
       if($configuration['external']['type'] == 'bond') {
         ::profile::infrastructure::ovs::port::bond { $configuration['external']['name']:
           bridge  => $name,
           members => $configuration['external']['members'],
         }
       }
+      # The connection might be a single interface
       if($configuration['external']['type'] == 'interface') {
         ::profile::infrastructure::ovs::port::interface { $configuration['external']['name']:
           bridge => $name,
+        }
+      }
+      # The connection might be a patch connected to a certain VLAN of another
+      # ovs-bridge.
+      if($configuration['external']['type'] == 'vlan-patch') {
+        ::profile::infrastructure::ovs::patch::vlan {"${name}-vlan-patch":
+          source_bridge      => $configuration['external']['bridge'],
+          source_vlan        => $configuration['external']['vlan'],
+          destination_bridge => $name,
         }
       }
     }


### PR DESCRIPTION
This patch allows a vswitch to have its uplinkt through another vswitch. It also supports an opt-out from the 'match-on-mac' added to netplan config.

A vswitch 'lower' can have its uplink through the vswitch 'upstream' using the following in hiera:
```
profile::baseconfig::network::bridges:
   lower:
      external:
         type: 'vlan-patch'
         bridge: 'upstream'
         vlan: 1337
```