### PR TITLE
Rocky

### DIFF
--- a/files/sensuplugins/check_failed_builds.py
+++ b/files/sensuplugins/check_failed_builds.py
@@ -40,7 +40,7 @@ try:
             print("CRITICAL - Nova failed build count has increased from {} to {}".format(previous_failed_builds, current_failed_builds))
             exitcode=2
         else:
-            print("OK - Nova failed build count is not increasing")
+            print("OK - Nova failed build count is {}, and it's not increasing".format(current_failed_builds))
             exitcode=0
         with open(tmpfilepath, 'w') as tmpfile:
             tmpfile.write(str(current_failed_builds))

--- a/files/sensuplugins/check_failed_builds.py
+++ b/files/sensuplugins/check_failed_builds.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+import pymysql.cursors
+import socket
+import json
+import argparse
+import os
+import sys
+
+parser = argparse.ArgumentParser(description='Check amount of failed builds for nova-compute.')
+parser.add_argument('--host', help="MySQL host address")
+parser.add_argument('--user', help="Database user name", default='nova')
+parser.add_argument('--password', help="Database password")
+args = parser.parse_args()
+
+dbhost = args.host
+dbuser = args.user
+dbpass = args.password
+hostname = socket.gethostname()
+
+tmpfilepath = '/tmp/nova_failed_builds_count'
+
+try:
+    with open(tmpfilepath, 'r') as tmpfile:
+        previous_failed_builds = int(tmpfile.readline())
+except FileNotFoundError:
+    previous_failed_builds = 0
+
+
+try:
+    connection = pymysql.connect(host=dbhost,
+                                 user=dbuser,
+                                 db='nova',
+                                 password=dbpass,
+                                 cursorclass=pymysql.cursors.DictCursor)
+    with connection.cursor() as cursor:
+        sql = "SELECT stats FROM compute_nodes WHERE host=%s"
+        cursor.execute(sql, hostname)
+        result = cursor.fetchone()
+        current_failed_builds = int(json.loads(result['stats'])['failed_builds'])
+        if current_failed_builds > previous_failed_builds:
+            print("CRITICAL - Nova failed build count has increased from {} to {}".format(previous_failed_builds, current_failed_builds))
+            exitcode=2
+        else:
+            print("OK - Nova failed build count is not increasing")
+            exitcode=0
+        with open(tmpfilepath, 'w') as tmpfile:
+            tmpfile.write(str(current_failed_builds))
+
+    connection.close()
+
+except:
+    print("UNKNOWN - Something wrong happened with the database connection")
+    exitcode=3
+
+sys.exit(exitcode)

--- a/files/sensuplugins/check_failed_builds.py
+++ b/files/sensuplugins/check_failed_builds.py
@@ -25,7 +25,6 @@ try:
 except FileNotFoundError:
     previous_failed_builds = 0
 
-
 try:
     connection = pymysql.connect(host=dbhost,
                                  user=dbuser,

--- a/manifests/infrastructure/ovs/patch.pp
+++ b/manifests/infrastructure/ovs/patch.pp
@@ -19,6 +19,8 @@ define profile::infrastructure::ovs::patch (
   # Make sure there is a bridge connected to the physical interface.
   if ! defined(Profile::Infrastructure::Ovs::Bridge["br-vlan-${physical_if}"]) {
     ::profile::infrastructure::ovs::bridge { "br-vlan-${physical_if}" : }
+  }
+  if ! defined(Profile::Infrastructure::Ovs::Port::Interface[$physical_if]) {
     ::profile::infrastructure::ovs::port::interface { $physical_if: }
   }
 
@@ -28,6 +30,9 @@ define profile::infrastructure::ovs::patch (
   exec { "/usr/local/bin/addPatch.sh ${scriptArgs}":
     unless  => "/usr/local/bin/addPatch.sh ${scriptArgs} --verify",
     path    => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-    require => Profile::Infrastructure::Ovs::Bridge["br-vlan-${physical_if}"],
+    require => [
+      Profile::Infrastructure::Ovs::Bridge["br-vlan-${physical_if}"],
+      Profile::Infrastructure::Ovs::Port::Interface[$physical_if],
+    ],
   }
 }

--- a/manifests/infrastructure/ovs/port/interface.pp
+++ b/manifests/infrastructure/ovs/port/interface.pp
@@ -5,8 +5,30 @@ define profile::infrastructure::ovs::port::interface (
 ) {
   require ::vswitch::ovs
 
+  # Connects the physical interface to the bridge
   vs_port { $interface :
-    ensure => 'present',
-    bridge => $bridge,
+    ensure  => 'present',
+    bridge  => $bridge,
+    require => Vs_bridge[$bridge],
+  }
+
+  # Make sure that the physical port is configured to be up.
+  $distro = $facts['os']['release']['major']
+  if($distro == '18.04') {
+    file { "/etc/netplan/02-vswitch-${interface}.yaml":
+      ensure  => file,
+      mode    => '0644',
+      owner   => root,
+      group   => root,
+      content => epp('profile/netplan/manual.epp', {
+        'ifname' => $interface,
+      }),
+      notify  => Exec['netplan_apply'],
+    }
+  } elsif($distro == '16.04') {
+    ::network::interface { "manual-up-${interface}":
+      interface => $interface,
+      method    => 'manual', 
+    }
   }
 }

--- a/manifests/sensu/checks.pp
+++ b/manifests/sensu/checks.pp
@@ -17,5 +17,6 @@ class profile::sensu::checks {
   contain ::profile::sensu::checks::openstack::adminapi
   contain ::profile::sensu::checks::openstack::floatingip
   contain ::profile::sensu::checks::openstack::publicapi
+  contain ::profile::sensu::checks::openstack::failedbuilds
 
 }

--- a/manifests/sensu/checks/openstack/adminapi.pp
+++ b/manifests/sensu/checks/openstack/adminapi.pp
@@ -10,12 +10,6 @@ class profile::sensu::checks::openstack::adminapi inherits profile::sensu::check
     standalone  => false,
     subscribers => [ 'os-admin-api-checks' ],
   }
-  sensu::check { 'openstack-identity-admin-api':
-    command     => "check-http.rb -u ${api}:35357/v2.0",
-    interval    => 300,
-    standalone  => false,
-    subscribers => [ 'os-admin-api-checks' ],
-  }
   sensu::check { 'openstack-network-admin-api':
     command     => "check-http.rb -u ${api}:9696/v2.0 --response-code 401",
     interval    => 300,

--- a/manifests/sensu/checks/openstack/failedbuilds.pp
+++ b/manifests/sensu/checks/openstack/failedbuilds.pp
@@ -1,0 +1,15 @@
+# A sensu check that checks if nova-compute has increasing failed builds
+class profile::sensu::checks::openstack::failedbuilds {
+  $db_host = lookup('ntnuopenstack::nova::mysql::ip')
+  $db_user = lookup('ntnuopenstack::nova::mysql::user', {
+    'default_value' => 'nova',
+    'value_type'    => String,
+  })
+
+  sensu::check { 'openstack-compute-failed-builds':
+    command     => "/etc/sensu/plugins/extra/check_failed_builds.py --host ${db_host} --user ${db_user} --password :::os.nova-db-pw::",
+    interval    => 300,
+    standalone  => false,
+    subscribers => [ 'os-compute' ],
+  }
+}

--- a/manifests/sensu/checks/openstack/failedbuilds.pp
+++ b/manifests/sensu/checks/openstack/failedbuilds.pp
@@ -7,7 +7,7 @@ class profile::sensu::checks::openstack::failedbuilds {
   })
 
   sensu::check { 'openstack-compute-failed-builds':
-    command     => "/etc/sensu/plugins/extra/check_failed_builds.py --host ${db_host} --user ${db_user} --password :::os.nova-db-pw::",
+    command     => "/etc/sensu/plugins/extra/check_failed_builds.py --host ${db_host} --user ${db_user} --password :::os.nova-db-pw:::",
     interval    => 300,
     standalone  => false,
     subscribers => [ 'os-compute' ],

--- a/manifests/sensu/checks/openstack/publicapi.pp
+++ b/manifests/sensu/checks/openstack/publicapi.pp
@@ -9,12 +9,6 @@ class profile::sensu::checks::openstack::publicapi inherits profile::sensu::chec
     standalone  => false,
     subscribers => [ 'os-public-api-checks' ],
   }
-  sensu::check { 'openstack-identity-public-api':
-    command     => "check-http.rb -u ${api}:5000/v2.0",
-    interval    => 300,
-    standalone  => false,
-    subscribers => [ 'os-public-api-checks' ],
-  }
   sensu::check { 'openstack-network-public-api':
     command     => "check-http.rb -u ${api}:9696/v2.0 --response-code 401",
     interval    => 300,


### PR DESCRIPTION
For openstack-rocky the following changes are introduced to the profile-repo:
 - Add a sensu-check to monitor the 'failed-build' counter
 - A more robust way of attaching physical interfaces to v-switches.
 - Removed the sensu-check for the keystone v2 API.