### PR TITLE
Install ceph client libraries

### DIFF
--- a/manifests/ceph/client.pp
+++ b/manifests/ceph/client.pp
@@ -13,7 +13,7 @@ class profile::ceph::client {
       value => true;
   }
 
-  ensure_packages ( ['rbd-nbd'], {
+  ensure_packages ( ['rbd-nbd', 'python3-rbd', 'python3-rados'], {
     'ensure' => 'present',
   })
 }


### PR DESCRIPTION
As ntnuopenstack & friends uses python3 for stein and onwards we need to make sure that the ceph-libraries for python3 are installed.