### PR TITLE
Sudo config framework, netplan bugfix and monitoring of links used as vswitch uplinks.

### DIFF
--- a/files/sudo/administrator_sudoers
+++ b/files/sudo/administrator_sudoers
@@ -1,7 +1,7 @@
 Defaults:%administrator secure_path="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/puppetlabs/bin:/usr/ntnusky/tools"
 
 # Allow the administrator to halt and reboot the machine
-%administrator ALL=(root): /sbin/halt, /sbin/shutdown, /sbin/reboot
+%administrator ALL=(root) /sbin/halt, /sbin/shutdown, /sbin/reboot
 
 # Allow the admnistrator to perform a puppet-run
 %administrator ALL=(root) NOPASSWD: /opt/puppetlabs/bin/puppet agent -t *

--- a/files/sudo/administrator_sudoers
+++ b/files/sudo/administrator_sudoers
@@ -1,3 +1,3 @@
 Defaults:%administrator secure_path="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/puppetlabs/bin:/usr/ntnusky/tools"
 
-%administrator ALL=(root) NOPASSWD: puppet agent * 
+%administrator ALL=(root) NOPASSWD: /opt/puppetlabs/bin/puppet agent * 

--- a/files/sudo/administrator_sudoers
+++ b/files/sudo/administrator_sudoers
@@ -1,3 +1,3 @@
 Defaults:administrator secure_path="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/puppetlabs/bin:/usr/ntnusky/tools"
 
-%administrator ALL=(root) NOPASSWD: puppet agent --test
+%administrator ALL=(root) NOPASSWD: /opt/puppetlabs/bin/puppet agent * 

--- a/files/sudo/administrator_sudoers
+++ b/files/sudo/administrator_sudoers
@@ -1,3 +1,8 @@
 Defaults:%administrator secure_path="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/puppetlabs/bin:/usr/ntnusky/tools"
 
-%administrator ALL=(root) NOPASSWD: /opt/puppetlabs/bin/puppet agent * 
+# Allow the administrator to halt and reboot the machine
+%administrator ALL=(root): /sbin/halt, /sbin/shutdown, /sbin/reboot
+
+# Allow the admnistrator to perform a puppet-run
+%administrator ALL=(root) NOPASSWD: /opt/puppetlabs/bin/puppet agent -t *
+%administrator ALL=(root) NOPASSWD: /opt/puppetlabs/bin/puppet agent --test * 

--- a/files/sudo/administrator_sudoers
+++ b/files/sudo/administrator_sudoers
@@ -1,3 +1,3 @@
-Defaults:administrator secure_path="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/puppetlabs/bin:/usr/ntnusky/tools"
+Defaults:%administrator secure_path="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/puppetlabs/bin:/usr/ntnusky/tools"
 
-%administrator ALL=(root) NOPASSWD: /opt/puppetlabs/bin/puppet agent * 
+%administrator ALL=(root) NOPASSWD: puppet agent * 

--- a/files/sudo/administrator_sudoers
+++ b/files/sudo/administrator_sudoers
@@ -1,0 +1,3 @@
+Defaults:administrator secure_path="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/puppetlabs/bin:/usr/ntnusky/tools"
+
+%administrator ALL=(root) NOPASSWD: puppet agent --test

--- a/manifests/baseconfig/network/netplan.pp
+++ b/manifests/baseconfig/network/netplan.pp
@@ -71,8 +71,10 @@ class profile::baseconfig::network::netplan (Hash $nics) {
         $v6policy = undef
       }
       if($v4route) or ($v6route) {
-        $routes   = { 'routes'         => [ $v4route, $v4defroute, $v6defroute, $v6route ] }
-        $policies = { 'routing_policy' => [ $v4policy, $v6policy ] }
+        $routes   = { 
+          'routes' => [ $v4route, $v4defroute, $v6defroute, $v6route ] - undef
+        }
+        $policies = { 'routing_policy' => [ $v4policy, $v6policy ] - undef }
       } else {
         $routes   = { 'routes'         => undef }
         $policies = { 'routing_policy' => undef }

--- a/manifests/baseconfig/sudo.pp
+++ b/manifests/baseconfig/sudo.pp
@@ -13,7 +13,7 @@ class profile::baseconfig::sudo {
   }
 
   sudo::conf { 'administrator':
-    priority => 20,
-    content  => 'Defaults:administrator	secure_path="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/puppetlabs/bin:/usr/ntnusky/tools"',
+    priority => 11,
+    source   => 'puppet:///modules/profile/sudo/administrator_sudoers',
   }
 }

--- a/manifests/baseconfig/sudo.pp
+++ b/manifests/baseconfig/sudo.pp
@@ -11,4 +11,9 @@ class profile::baseconfig::sudo {
     priority => 15,
     source   => 'puppet:///modules/profile/sudo/sensu_sudoers',
   }
+
+  sudo::conf { 'administrator':
+    priority => 20,
+    content  => 'Defaults:administrator	secure_path="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/puppetlabs/bin:/usr/ntnusky/tools"',
+  }
 }

--- a/manifests/baseconfig/users.pp
+++ b/manifests/baseconfig/users.pp
@@ -11,6 +11,10 @@ class profile::baseconfig::users {
     ensure => present,
     gid    => 700,
   }
+  group { 'administrator':
+    ensure => present,
+    gid    => 701,
+  }
 
   # Modify root's attributes
   file { '/root/.ssh':

--- a/manifests/infrastructure/ovs/port/bond.pp
+++ b/manifests/infrastructure/ovs/port/bond.pp
@@ -5,17 +5,20 @@ define profile::infrastructure::ovs::port::bond (
 ) {
   require ::profile::infrastructure::ovs::script::bond
 
+  # Use the create-vswitch-lacp.sh.sh script to create the bond, and connect it
+  # to the bridge.
   $memberstring = join($members, ' ')
   $args = "${name} ${memberstring}"
-
   exec { "/usr/local/bin/create-vswitch-lacp.sh.sh ${bridge} ${args}":
     unless  => "/usr/local/bin/verify-vswitch-lacp.sh.sh ${args}",
     path    => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
     require => Profile::Infrastructure::Ovs::Bridge[$bridge],
   }
 
+  # Iterate through all the member ports:
   $distro = $facts['os']['release']['major']
   $members.each | $member | {
+    # Make sure the physical port is up
     if($distro == '18.04') {
       file { "/etc/netplan/02-bondmember-${member}.yaml":
         ensure  => file,
@@ -30,8 +33,20 @@ define profile::infrastructure::ovs::port::bond (
     } elsif($distro == '16.04') {
       ::network::interface { "manual-up-${member}":
         interface => $member,
-        method    => 'manual', 
+        method    => 'manual',
       }
+    }
+
+    # Add monitoring for the physical port
+    munin::plugin { "if_${member}":
+      ensure => link,
+      target => 'if_',
+      config => ['user root', 'env.speed 10000'],
+    }
+    munin::plugin { "if_err_${member}":
+      ensure => link,
+      target => 'if_err_',
+      config => ['user nobody'],
     }
   }
 }

--- a/manifests/infrastructure/ovs/port/interface.pp
+++ b/manifests/infrastructure/ovs/port/interface.pp
@@ -28,7 +28,19 @@ define profile::infrastructure::ovs::port::interface (
   } elsif($distro == '16.04') {
     ::network::interface { "manual-up-${interface}":
       interface => $interface,
-      method    => 'manual', 
+      method    => 'manual',
     }
+  }
+
+  # Add monitoring for the physical port
+  munin::plugin { "if_${interface}":
+    ensure => link,
+    target => 'if_',
+    config => ['user root', 'env.speed 10000'],
+  }
+  munin::plugin { "if_err_${interface}":
+    ensure => link,
+    target => 'if_err_',
+    config => ['user nobody'],
   }
 }


### PR DESCRIPTION
### Initial framework for sudo

There is created a group called 'administrator' which will get sudo-configuration to enable administrators to do regular day-to-day non-interuptive tasks without authentication. Currently the only configuration added are the possibility to perform a puppet-run without auth, but we should add more as we start configuring various services. Candidates for this are at least:
 - service-restarts
 - haproxy maintainance-script
 - display ceph-status
 - Setting/clearing ceph noout

### Other changes:
 - Small bugfix in netplan-logic preventing hosts with blank config from creating multiple interfaces with static IP assignment and seperate routing tables.
 - Add monitoring to physical interfaces used as uplinks from vswitches.
