### PR TITLE
Add support for setting MTU on vswitch ports

### DIFF
--- a/manifests/baseconfig/network/netplan.pp
+++ b/manifests/baseconfig/network/netplan.pp
@@ -12,7 +12,7 @@ class profile::baseconfig::network::netplan (Hash $nics) {
     $table_id = $nics[$nic]['tableid']
     $mtu   = { 'mtu'   => $nics[$nic]['mtu'] }
     if ( $nic =~ /^(lo|infra)/ or $nics[$nic]['nomatch'] or
-        ! $nic in $::facts['networking']['interfaces']) {
+        !($nic in $::facts['networking']['interfaces'])) {
       $match = {}
     } else {
       $mac = $::facts['networking']['interfaces'][$nic]['mac']

--- a/manifests/baseconfig/network/netplan.pp
+++ b/manifests/baseconfig/network/netplan.pp
@@ -12,7 +12,7 @@ class profile::baseconfig::network::netplan (Hash $nics) {
     $table_id = $nics[$nic]['tableid']
     $mtu   = { 'mtu'   => $nics[$nic]['mtu'] }
     if ( $nic =~ /^(lo|infra)/ or $nics[$nic]['nomatch'] or
-        not $::facts['networking']['interfaces'][$nic]) {
+        ! $nic in $::facts['networking']['interfaces']) {
       $match = {}
     } else {
       $mac = $::facts['networking']['interfaces'][$nic]['mac']
@@ -21,7 +21,7 @@ class profile::baseconfig::network::netplan (Hash $nics) {
 
     # If the interface should have its own routing-table, and it already exists,
     # configure the routing-table adding gateways etc.
-    if($table_id and $::facts['networking']['interfaces'][$nic]) {
+    if($table_id and $nic in $::facts['networking']['interfaces']) {
       if($::facts['networking']['interfaces'][$nic]['ip']) {
         $net4id = $::facts['networking']['interfaces'][$nic]['network']
         $net4mask = netmask_to_masklen($::facts['networking']['interfaces'][$nic]['netmask'])

--- a/manifests/baseconfig/network/netplan.pp
+++ b/manifests/baseconfig/network/netplan.pp
@@ -11,14 +11,17 @@ class profile::baseconfig::network::netplan (Hash $nics) {
     $nic = $n[0]
     $table_id = $nics[$nic]['tableid']
     $mtu   = { 'mtu'   => $nics[$nic]['mtu'] }
-    if ( $nic =~ /^(lo|infra)/ or $nics[$nic]['nomatch']) {
+    if ( $nic =~ /^(lo|infra)/ or $nics[$nic]['nomatch'] or
+        not $::facts['networking']['interfaces'][$nic]) {
       $match = {}
     } else {
       $mac = $::facts['networking']['interfaces'][$nic]['mac']
       $match = { 'match' => {'macaddress' => $mac} }
     }
 
-    if($table_id) {
+    # If the interface should have its own routing-table, and it already exists,
+    # configure the routing-table adding gateways etc.
+    if($table_id and $::facts['networking']['interfaces'][$nic]) {
       if($::facts['networking']['interfaces'][$nic]['ip']) {
         $net4id = $::facts['networking']['interfaces'][$nic]['network']
         $net4mask = netmask_to_masklen($::facts['networking']['interfaces'][$nic]['netmask'])
@@ -71,7 +74,7 @@ class profile::baseconfig::network::netplan (Hash $nics) {
         $v6policy = undef
       }
       if($v4route) or ($v6route) {
-        $routes   = { 
+        $routes   = {
           'routes' => [ $v4route, $v4defroute, $v6defroute, $v6route ] - undef
         }
         $policies = { 'routing_policy' => [ $v4policy, $v6policy ] - undef }

--- a/manifests/baseconfig/networking.pp
+++ b/manifests/baseconfig/networking.pp
@@ -31,18 +31,34 @@ class profile::baseconfig::networking {
 
     # If the bridge should have an external connection
     if($configuration['external']) {
+      if($configuration['external']['mtu']) {
+        $mtu = $configuration['external']['mtu']
+      } else {
+        $mtu = 1500
+      }
+      if($configuration['external']['driver']) {
+        $driver = $configuration['external']['driver']
+      } else {
+        $driver = ''
+      }
+
       # The connection might be a bond consisting of multiple physical
       # interfaces:
       if($configuration['external']['type'] == 'bond') {
-        ::profile::infrastructure::ovs::port::bond { $configuration['external']['name']:
+        ::profile::infrastructure::ovs::port::bond {
+            $configuration['external']['name']:
           bridge  => $name,
           members => $configuration['external']['members'],
+          mtu     => $mtu,
         }
       }
       # The connection might be a single interface
       if($configuration['external']['type'] == 'interface') {
-        ::profile::infrastructure::ovs::port::interface { $configuration['external']['name']:
+        ::profile::infrastructure::ovs::port::interface {
+            $configuration['external']['name']:
           bridge => $name,
+          driver => $driver,
+          mtu    => $mtu,
         }
       }
       # The connection might be a patch connected to a certain VLAN of another

--- a/manifests/baseconfig/networking.pp
+++ b/manifests/baseconfig/networking.pp
@@ -27,7 +27,9 @@ class profile::baseconfig::networking {
   })
   $bridges.each | $name, $configuration | {
     # Create a bridge
-    ::profile::infrastructure::ovs::bridge { $name : }
+    ::profile::infrastructure::ovs::bridge { $name :
+      mtu => $configuration['mtu'],
+    }
 
     # If the bridge should have an external connection
     if($configuration['external']) {

--- a/manifests/infrastructure/ovs/bridge.pp
+++ b/manifests/infrastructure/ovs/bridge.pp
@@ -1,8 +1,18 @@
 # Create an openvswitch bridge
-define profile::infrastructure::ovs::bridge {
+define profile::infrastructure::ovs::bridge (
+  Variant[Integer, Undef] $mtu = undef,
+) {
   require ::vswitch::ovs
 
   vs_bridge { $name:
     ensure => 'present',
+  }
+
+  if($mtu) {
+    $getcmd = "/usr/bin/ovs-vsctl get interface ${name} mtu_request"
+    exec { "/usr/bin/ovs-vsctl set interface ${name} mtu_request=${mtu}":
+      unless  => "[ \$(${getcmd}) -eq ${mtu} ]",
+      require => Vs_bridge[$name],
+    }
   }
 }

--- a/manifests/infrastructure/ovs/bridge.pp
+++ b/manifests/infrastructure/ovs/bridge.pp
@@ -9,9 +9,10 @@ define profile::infrastructure::ovs::bridge (
   }
 
   if($mtu) {
-    $getcmd = "/usr/bin/ovs-vsctl get interface ${name} mtu_request"
-    exec { "/usr/bin/ovs-vsctl set interface ${name} mtu_request=${mtu}":
+    $getcmd = "ovs-vsctl get interface ${name} mtu_request"
+    exec { "ovs-vsctl set interface ${name} mtu_request=${mtu}":
       unless  => "[ \$(${getcmd}) -eq ${mtu} ]",
+      path    => '/usr/bin',
       require => Vs_bridge[$name],
     }
   }

--- a/manifests/infrastructure/ovs/port/interface.pp
+++ b/manifests/infrastructure/ovs/port/interface.pp
@@ -16,7 +16,7 @@ define profile::infrastructure::ovs::port::interface (
 
   if($::facts['networking']['interfaces'][$interface]) {
     $mac = {
-      'macaddress' => $::facts['networking']['interfaces'][$interface]['mac'],
+      'mac' => $::facts['networking']['interfaces'][$interface]['mac'],
     }
   } else {
     $mac = {}

--- a/manifests/infrastructure/ovs/port/interface.pp
+++ b/manifests/infrastructure/ovs/port/interface.pp
@@ -1,7 +1,9 @@
 # Connects a physical interface to an openvswitch bridge
 define profile::infrastructure::ovs::port::interface (
-  String $interface = $name,
-  String $bridge = "br-vlan-${name}",
+  String  $interface = $name,
+  String  $bridge = "br-vlan-${name}",
+  String  $driver = '',
+  Integer $mtu = 1500,
 ) {
   require ::vswitch::ovs
 
@@ -12,23 +14,40 @@ define profile::infrastructure::ovs::port::interface (
     require => Vs_bridge[$bridge],
   }
 
+  if($::facts['networking']['interfaces'][$interface]) {
+    $mac = {
+      'macaddress' => $::facts['networking']['interfaces'][$interface]['mac'],
+    }
+  } else {
+    $mac = {}
+  }
+
   # Make sure that the physical port is configured to be up.
   $distro = $facts['os']['release']['major']
   if($distro == '18.04') {
+    if($driver == '') {
+      $parameters = { 'ifname' => $interface }
+    } else {
+      $parameters = {
+        'drivername' => $driver,
+        'ifname'     => $interface,
+        'mtu'        => $mtu,
+      }
+    }
+
     file { "/etc/netplan/02-vswitch-${interface}.yaml":
       ensure  => file,
       mode    => '0644',
       owner   => root,
       group   => root,
-      content => epp('profile/netplan/manual.epp', {
-        'ifname' => $interface,
-      }),
+      content => epp('profile/netplan/manual.epp', $parameters + $mac),
       notify  => Exec['netplan_apply'],
     }
   } elsif($distro == '16.04') {
     ::network::interface { "manual-up-${interface}":
       interface => $interface,
       method    => 'manual',
+      mtu       => $mtu,
     }
   }
 

--- a/templates/netplan/manual.epp
+++ b/templates/netplan/manual.epp
@@ -1,7 +1,19 @@
 <%- | String  $ifname,
+      String  $mac = '',
+      Integer $mtu = 1500,
+      String  $drivername = '',
 | -%>
 network:
   version: 2
   renderer: networkd
   ethernets:
+<% if $drivername == '' or $mac == '' { -%>
     <%= $ifname %>: {}
+<% } else { -%>
+    <%= $ifname %>:
+      match:
+        driver: "<%= $drivername %>"
+        macaddress: "<%= $mac %>"
+      mtu: <%= $mtu %>
+<% } -%>
+

--- a/templates/netplan/manual.epp
+++ b/templates/netplan/manual.epp
@@ -1,7 +1,7 @@
-<%- | String  $ifname,
-      String  $mac = '',
-      Integer $mtu = 1500,
-      String  $drivername = '',
+<%- | String            $ifname,
+      Optional[String]  $mac = '',
+      Optional[Integer] $mtu = 1500,
+      Optional[String]  $drivername = '',
 | -%>
 network:
   version: 2


### PR DESCRIPTION
Add support for setting MTU on vswitch ports

When defining an external connection for a vswitch in hiera, you
can define an MTU setting for the interface. For a single interface
you could add the following in hiera:

```
profile::baseconfig::network::bridges:
  bridgename:
    external:
      type: 'interface'
      name: 'eno1'
      mtu: 9000
      driver: 'bnx2x'
```

For a bond the similar setup would look like so in hiera:

```
profile::baseconfig::network::bridges:
  bridgename:
    external:
      type: 'bond'
      mtu: 9000
      members:
        eno1:
          driver: 'bnx2x'
        eno2:
          driver: 'bnx2x'
```

To set an mtu-hint to a bridge without physical external connections, the following can work:

```
profile::baseconfig::network::bridges:
  bridgename:
    mtu: 9000
    external:
      type: 'vlan-patch'
      bridge: 'otherbridge'
      vlan: 1337
```

NOTE: Du to a current bug in netplan we need to match a specific interface to
set the MTU-value. When using vswitches as we do, we need to match both
mac-address and drivername to sit with a single interface. This is the reason
behind the driver-option.
