### PR TITLE
Multiple BGP peers, Bird static routes and BGP multihop

### DIFF
--- a/manifests/bird/config/bgp.pp
+++ b/manifests/bird/config/bgp.pp
@@ -5,6 +5,7 @@ define profile::bird::config::bgp (
   Integer $aslocal,
   Integer $asremote,
   String $neighbourip,
+  Integer $multihop = 1,
 ) {
   concat::fragment { "Bird BGP ${name}":
     target  => $configfile,
@@ -13,6 +14,7 @@ define profile::bird::config::bgp (
       'aslocal'     => $aslocal,
       'asremote'    => $asremote,
       'neighbourIP' => $neighbourip,
+      'multihop'    => $multihop,
     }),
     order   => '15'
   }

--- a/manifests/bird/config/static.pp
+++ b/manifests/bird/config/static.pp
@@ -1,7 +1,7 @@
 # Adds static-routes for bird
 define profile::bird::config::static (
   String $configfile,
-  Array $prefixes,
+  Hash $prefixes,
 ) {
   concat::fragment { "Bird Static ${name}":
     target  => $configfile,

--- a/manifests/bird/config/static.pp
+++ b/manifests/bird/config/static.pp
@@ -1,0 +1,13 @@
+# Adds static-routes for bird
+define profile::bird::config::static (
+  String $configfile,
+  Array $prefixes,
+) {
+  concat::fragment { "Bird Static ${name}":
+    target  => $configfile,
+    content => epp('profile/bird/static.epp', {
+      'prefixes' => $prefixes,
+    }),
+    order   => '13'
+  }
+}

--- a/manifests/bird/ipv4.pp
+++ b/manifests/bird/ipv4.pp
@@ -15,16 +15,34 @@ class profile::bird::ipv4 {
     $remote_as = lookup('profile::bird::anycast::ipv4::bgp::as::remote', {
       'value_type'    => Integer,
     })
+    $multihop = lookup('profile::bird::anycast::ipv4::bgp::multihop', {
+      'value_type'    => Integer,
+      'default_value' => 1,
+    })
     $neighbour = lookup('profile::bird::anycast::ipv4::bgp::peer', {
-      'value_type'    => String,
+      'value_type'    => Variant[String, Boolean],
+      'default_value' => false,
+    })
+    $_neighbours = lookup('profile::bird::anycast::ipv4::bgp::peers', {
+      'value_type'    => Array[String],
+      'default_value' => [],
     })
 
-    ::profile::bird::config::bgp { 'v4anycast':
-      configfile  => '/etc/bird/bird.conf',
-      filtername  => 'v4anycast',
-      aslocal     => $local_as,
-      asremote    => $remote_as,
-      neighbourip => $neighbour,
+    if($neighbour) {
+      $neighbours = $_neighbours <<  $neighbour
+    } else {
+      $neighbours = $_neighbours
+    }
+
+    $neighbours.each | $peer | {
+      ::profile::bird::config::bgp { 'v4anycast':
+        configfile  => '/etc/bird/bird.conf',
+        filtername  => 'v4anycast',
+        aslocal     => $local_as,
+        asremote    => $remote_as,
+        multihop    => $multihop,
+        neighbourip => $peer,
+      }
     }
 
     ::profile::bird::config::filter { 'v4anycast':

--- a/manifests/bird/ipv4.pp
+++ b/manifests/bird/ipv4.pp
@@ -35,7 +35,7 @@ class profile::bird::ipv4 {
     }
 
     $neighbours.each | $peer | {
-      ::profile::bird::config::bgp { 'v4anycast':
+      ::profile::bird::config::bgp { "v4anycast-${peer}":
         configfile  => '/etc/bird/bird.conf',
         filtername  => 'v4anycast',
         aslocal     => $local_as,

--- a/manifests/bird/ipv4.pp
+++ b/manifests/bird/ipv4.pp
@@ -27,6 +27,13 @@ class profile::bird::ipv4 {
       'value_type'    => Array[String],
       'default_value' => [],
     })
+    $statics = lookup('profile::bird::ipv4::static', {
+      'value_type'    => Variant[
+        Boolean,
+        Hash[Stdlib::IP::Address::V4::CIDR, Hash],
+      ],
+      'default_value' => false
+    })
 
     if($neighbour) {
       $neighbours = $_neighbours <<  $neighbour
@@ -48,6 +55,13 @@ class profile::bird::ipv4 {
     ::profile::bird::config::filter { 'v4anycast':
       configfile => '/etc/bird/bird.conf',
       prefixes   => [ "${anycastv4}/32" ],
+    }
+
+    if($statics) {
+      ::profile::bird::config::static { 'v4anycast':
+        configfile => '/etc/bird/bird.conf',
+        prefixes   => $statics,
+      }
     }
   }
 }

--- a/templates/bird/bgp.epp
+++ b/templates/bird/bgp.epp
@@ -2,9 +2,11 @@
       Integer $aslocal,
       Integer $asremote,
       String $neighbourIP,
+      Integer $multihop,
 | -%>
 protocol bgp {
   export filter <%= $filtername %>;
+  multihop <%= $multihop %>;
   local as <%= $aslocal %>;
   neighbor <%= $neighbourIP %> as <%= $asremote %>;
 }

--- a/templates/bird/static.epp
+++ b/templates/bird/static.epp
@@ -1,4 +1,4 @@
-<%- | Array $prefixes,
+<%- | Hash $prefixes,
 | -%>
 protocol static {
 <% $prefixes.each |$prefix, $data| { -%>

--- a/templates/bird/static.epp
+++ b/templates/bird/static.epp
@@ -1,0 +1,7 @@
+<%- | Array $prefixes,
+| -%>
+protocol static {
+<% $prefixes.each |$prefix, $data| { -%>
+  route <%= $prefix %> via <%= $data['next-hop'] %>;
+<% } -%>
+}


### PR DESCRIPTION
This release introduces the following changes to bird:
 - Allows more than one BGP peer
 - Allows configuration of multihop, in case the BGP-peer is not on the local subnet.
 - Allows configuration of static-routes to define the first-hop for a certain BGP peer.

### New hiera-keys:
 - `profile::bird::anycast::ipv4::bgp::multihop`: An integer to define
   the TTL of BGP-packets sent from this hop. Defaults to 1.
 - `profile::bird::anycast::ipv4::bgp::peers`: A list of IP-adresses which
   should be used for BGP peering.
 - `profile::bird::ipv4::static` - Hash where the keys are a network CIDR, and the
value is a new hash with at least one item: next-hop.

### Deprecated hiera-keys:
 - `profile::bird::anycast::ipv4::bgp::peer`: This key is currently concatinated
   with the list at `profile:bird:anycast::ipv4::bgp::peers`, but it will be
   removed in a future release. Please migrate to the 'peers' value.

### Example:

The static-routes might be defined like so in hiera:
```
profile::bird::ipv4::static:
  10.37.0.140/32:
    next-hop: '10.0.28.2'
  10.37.0.141/32:
    next-hop: '10.0.28.3'
```