### PR TITLE
Multiv6anycast - Multiple bgp-peers for ipv6 anycast

### DIFF
--- a/files/sudo/haproxy-manage_sudoers
+++ b/files/sudo/haproxy-manage_sudoers
@@ -5,10 +5,13 @@
 # Allow the administrators to start/stop haproxy and birds
 %administrator ALL=(root) /bin/systemctl stop bird
 %administrator ALL=(root) /bin/systemctl start bird
+%administrator ALL=(root) /bin/systemctl restart bird
 %administrator ALL=(root) NOPASSWD: /bin/systemctl status bird
 %administrator ALL=(root) /bin/systemctl stop bird6
 %administrator ALL=(root) /bin/systemctl start bird6
+%administrator ALL=(root) /bin/systemctl restart bird6
 %administrator ALL=(root) NOPASSWD: /bin/systemctl status bird6
 %administrator ALL=(root) /bin/systemctl stop haproxy
 %administrator ALL=(root) /bin/systemctl start haproxy
+%administrator ALL=(root) /bin/systemctl restart haproxy
 %administrator ALL=(root) NOPASSWD: /bin/systemctl status haproxy

--- a/files/sudo/haproxy-manage_sudoers
+++ b/files/sudo/haproxy-manage_sudoers
@@ -1,7 +1,14 @@
 # Allow the administrator to use the haproxy-manage scripts to manipulate the
 # loadbalancers.
-%administrator ALL=(root) NOPASSWD: /opt/puppetlabs/bin/puppet agent --test * 
+%administrator ALL=(root) NOPASSWD: /usr/local/sbin/haproxy-manage.sh 
 
 # Allow the administrators to start/stop haproxy and birds
-%administrator ALL=(root) /bin/systemctl (stop|start) (haproxy|bird|bird6)
-%administrator ALL=(root) NOPASSWD: /bin/systemctl status (haproxy|bird|bird6)
+%administrator ALL=(root) /bin/systemctl stop bird
+%administrator ALL=(root) /bin/systemctl start bird
+%administrator ALL=(root) NOPASSWD: /bin/systemctl status bird
+%administrator ALL=(root) /bin/systemctl stop bird6
+%administrator ALL=(root) /bin/systemctl start bird6
+%administrator ALL=(root) NOPASSWD: /bin/systemctl status bird6
+%administrator ALL=(root) /bin/systemctl stop haproxy
+%administrator ALL=(root) /bin/systemctl start haproxy
+%administrator ALL=(root) NOPASSWD: /bin/systemctl status haproxy

--- a/files/sudo/haproxy-manage_sudoers
+++ b/files/sudo/haproxy-manage_sudoers
@@ -1,0 +1,7 @@
+# Allow the administrator to use the haproxy-manage scripts to manipulate the
+# loadbalancers.
+%administrator ALL=(root) NOPASSWD: /opt/puppetlabs/bin/puppet agent --test * 
+
+# Allow the administrators to start/stop haproxy and birds
+%administrator ALL=(root) /bin/systemctl (stop|start) (haproxy|bird|bird6)
+%administrator ALL=(root) NOPASSWD: /bin/systemctl status (haproxy|bird|bird6)

--- a/manifests/bird/ipv6.pp
+++ b/manifests/bird/ipv6.pp
@@ -41,14 +41,14 @@ class profile::bird::ipv6 {
       $neighbours = $_neighbours
     }
 
-    $neighbours.each | $peeer | {
+    $neighbours.each | $peer | {
       ::profile::bird::config::bgp { "v6anycast-${peer}":
         configfile  => '/etc/bird/bird6.conf',
         filtername  => 'v6anycast',
         aslocal     => $local_as,
         asremote    => $remote_as,
         multihop    => $multihop,
-        neighbourip => $neighbour,
+        neighbourip => $peer,
       }
     }
 

--- a/manifests/bird/ipv6.pp
+++ b/manifests/bird/ipv6.pp
@@ -20,11 +20,11 @@ class profile::bird::ipv6 {
       'default_value' => 1,
     })
     $neighbour = lookup('profile::bird::anycast::ipv6::bgp::peer', {
-      'value_type'    => Variand[String, Boolean],
+      'value_type'    => Variant[String, Boolean],
       'default_value' => false,
     })
     $_neighbours = lookup('profile::bird::anycast::ipv6::peers', {
-      'value_type'    => Arrau[String],
+      'value_type'    => Array[String],
       'default_value' => [],
     })
     $statics = lookup('profile::bird::ipv6::static', {

--- a/manifests/bird/ipv6.pp
+++ b/manifests/bird/ipv6.pp
@@ -30,7 +30,7 @@ class profile::bird::ipv6 {
     $statics = lookup('profile::bird::ipv6::static', {
       'value_type'    => Variant[
         Boolean,
-        Hash[Stdlib::IP::Address::V4::CIDR, Hash],
+        Hash[Stdlib::IP::Address::V6::CIDR, Hash],
       ],
       'default_value' => false,
     })

--- a/manifests/bird/ipv6.pp
+++ b/manifests/bird/ipv6.pp
@@ -23,7 +23,7 @@ class profile::bird::ipv6 {
       'value_type'    => Variant[String, Boolean],
       'default_value' => false,
     })
-    $_neighbours = lookup('profile::bird::anycast::ipv6::peers', {
+    $_neighbours = lookup('profile::bird::anycast::ipv6::bgp::peers', {
       'value_type'    => Array[String],
       'default_value' => [],
     })

--- a/manifests/services/haproxy/tools.pp
+++ b/manifests/services/haproxy/tools.pp
@@ -20,6 +20,11 @@ class profile::services::haproxy::tools {
     order   => '01'
   }
 
+  sudo::conf { 'haproxy-manage':
+    priority => 50,
+    source   => 'puppet:///modules/profile/sudo/haproxy-manage_sudoers',
+  }
+
   file { '/usr/local/sbin/haproxy-manage.sh':
     ensure => present,
     owner  => 'root',


### PR DESCRIPTION
This change adds the hiera-key `profile::bird::anycast::ipv6::bgp::peers` and `profile::bird::ipv6::static` to allow configuring ipv6 similar to what we allow for IPv4.

Also bring in sudo-config for our loadbalancers to allow a future password-less administrator experience :)