### PR TITLE
Puppetcafixes

### DIFF
--- a/files/puppet/cabackup.sh
+++ b/files/puppet/cabackup.sh
@@ -6,24 +6,48 @@ sshprivkey='/etc/ssh/ssh_host_rsa_key'
 
 backuparchive="puppetca-$(hostname)-$(date +%Y%m%d-%H%M%S).tgz"
 
+logger "[Puppet-cabackup] Starting to backup puppetca certs"
+
 if [[ ! -e /var/backups/puppetca ]]; then
+  echo "[Puppet-cabackup] First time script is run. Create backup-catalog."
+  logger "[Puppet-cabackup] First time script is run. Create backup-catalog."
   mkdir /var/backups/puppetca
   chmod 0700 /var/backups/puppetca
 fi
 
+if [[ ! -e /var/log/puppetcabackup ]]; then
+  echo "[Puppet-cabackup] First time script is run. Create log-catalog."
+  logger "[Puppet-cabackup] First time script is run. Create log-catalog."
+  mkdir /var/log/puppetcabackup 
+  chmod 0700 /var/log/puppetcabackup
+fi
+
 # Create a new backup-archive
-tar -czf /var/backups/puppetca/$backuparchive $backupsource &> /dev/null
-chmod 0600 /var/backups/puppetca/$backuparchive
+logger "[Puppet-cabackup] Creating archive"
+tar -czf "/var/backups/puppetca/${backuparchive}" "$backupsource" &> /dev/null
+chmod 0600 "/var/backups/puppetca/${backuparchive}"
 
 # Delete all but the 10 most recent
-cd /var/backups/puppetca/
-ls -1tr | head -n -10 | xargs -d '\n' rm --
-cd -
+logger "[Puppet-cabackup] Deleting old catalogs"
+cd /var/backups/puppetca/ || exit 3
+ls -1tr | head -n -10 | xargs -d '\n' rm -- &> /dev/null
+cd - &> /dev/null || exit 3
 
 # Sync changes to the other puppet-masters.
 while IFS='' read -r line || [[ -n "$line" ]]; do
   if [[ $line =~ puppetmaster-(.*) ]] ; then
     hostname=${BASH_REMATCH[1]}
-    ssh-agent bash -c "ssh-add $sshprivkey; rsync -arv --delete /var/backups/puppetca ${hostname}:${backupdest}"
+    logger "[Puppet-cabackup] Syncing to $hostname"
+    ssh-agent bash -c "ssh-add $sshprivkey; rsync -arv --delete /var/backups/puppetca ${hostname}:${backupdest}" \
+        &> "/var/log/puppetcabackup/$hostname-$(date +%Y%m%d-%H%M%S).rsync.log"
   fi
 done < "/root/.ssh/authorized_keys"
+
+# Delete all but the most 1k recent logfiles
+logger "[Puppet-cabackup] Deleting old logfiles"
+cd /var/log/puppetcabackup/ || exit 3
+ls -1tr | head -n -1000 | xargs -d '\n' rm -- &> /dev/null
+cd - &> /dev/null || exit 3
+
+logger "[Puppet-cabackup] Backup complete" 
+exit 0

--- a/files/puppet/cabackup.sh
+++ b/files/puppet/cabackup.sh
@@ -4,9 +4,26 @@ backupsource='/etc/puppetlabs/puppet/ssl/ca'
 backupdest="/var/opt/puppet/$(hostname)/"
 sshprivkey='/etc/ssh/ssh_host_rsa_key'
 
+backuparchive="puppetca-$(hostname)-$(date +%Y%m%d-%H%M%S).tgz"
+
+if [[ ! -e /var/backups/puppetca ]]; then
+  mkdir /var/backups/puppetca
+  chmod 0700 /var/backups/puppetca
+fi
+
+# Create a new backup-archive
+tar -czf /var/backups/puppetca/$backuparchive $backupsource &> /dev/null
+chmod 0600 /var/backups/puppetca/$backuparchive
+
+# Delete all but the 10 most recent
+cd /var/backups/puppetca/
+ls -1tr | head -n -10 | xargs -d '\n' rm --
+cd -
+
+# Sync changes to the other puppet-masters.
 while IFS='' read -r line || [[ -n "$line" ]]; do
   if [[ $line =~ puppetmaster-(.*) ]] ; then
     hostname=${BASH_REMATCH[1]}
-    ssh-agent bash -c "ssh-add $sshprivkey; rsync -arv $backupsource ${hostname}:${backupdest}"
+    ssh-agent bash -c "ssh-add $sshprivkey; rsync -arv --delete /var/backups/puppetca ${hostname}:${backupdest}"
   fi
 done < "/root/.ssh/authorized_keys"

--- a/files/puppet/killr10k.sh
+++ b/files/puppet/killr10k.sh
@@ -31,8 +31,8 @@ while IFS='' read -r line || [[ -n "$line" ]]; do
 
     # If enough minutes, print a message and kill the process.
     if [[ $minutes -gt $maxminutes ]]; then
-      echo R10k process $pid was killed, as it had more than $maxminutes \
-          minutes CPU time.
+      logger "[r10k-killer] process $pid was killed, as it had more than" \
+          "$maxminutes minutes CPU time."
       kill -9 $pid
     fi
   fi

--- a/files/puppet/pull_hiera.sh
+++ b/files/puppet/pull_hiera.sh
@@ -2,16 +2,39 @@
 
 repolocation='/etc/puppetlabs/puppet/data/'
 sshprivkey='/etc/ssh/ssh_host_rsa_key'
+any=0
 
+logger "[pull-hieradata] Start to sync hiera from other puppetmasters"
 while IFS='' read -r line || [[ -n "$line" ]]; do
   if [[ $line =~ puppetmaster-(.*) ]] ; then
     hostname=${BASH_REMATCH[1]}
     if [[ ! -d $repolocation ]]; then
-      cd $(dirname $repolocation)
-      ssh-agent bash -c "ssh-add $sshprivkey; git clone ${hostname}:${repolocation}"
+      cd "$(dirname $repolocation)" || exit 2
+      if ssh-agent bash -c \
+          "ssh-add $sshprivkey; git clone ${hostname}:${repolocation}" &> \
+          /dev/null; then
+        logger "[pull-hieradata] Successfully cloned from ${hostname}"
+        any=1
+      else
+        logger "[pull-hieradata] Could not clone from ${hostname}"
+      fi
     else
-      cd $repolocation
-      ssh-agent bash -c "ssh-add $sshprivkey; git pull ${hostname}:${repolocation} --no-edit"
+      cd $repolocation || exit 2
+      if ssh-agent bash -c \
+          "ssh-add $sshprivkey; git pull ${hostname}:${repolocation} --no-edit" \
+          &> /dev/null; then
+        logger "[pull-hieradata] Successfully pulled from ${hostname}"
+        any=1
+      else
+        logger "[pull-hieradata] Could not pull from ${hostname}"
+      fi
     fi
   fi
 done < "/root/.ssh/authorized_keys"
+
+if [[ $any -eq 0 ]]; then
+  echo "Could not pull hieradata from anyone!"
+  logger "[pull-hieradata] Unable to retrieve hieradata."
+fi
+
+logger "[pull-hieradata] Finished sync of hieradata."

--- a/files/puppet/puppetcert_clean.sh
+++ b/files/puppet/puppetcert_clean.sh
@@ -34,7 +34,7 @@ logger "[PUPPET-CertClean] Got a list of ${noHosts} hosts from puppetca"
 # Loop trough all hosts which has a puppetcert, but is not listed in
 # shiftleader:
 toRevoke=()
-for host in $(echo ${allslhosts[@]} ${allslhosts[@]} ${allcahosts[@]} | \
+for host in $(echo "${allslhosts[@]}" "${allslhosts[@]}" "${allcahosts[@]}" | \
     tr ' ' '\n' | sort | uniq -u); do
   logger "[PUPPET-CertClean] The host $host not in shiftleader anymore"
   # add the host to the list of certs to be revoked
@@ -45,8 +45,7 @@ done
 installinghosts=$(/opt/shiftleader/manage.py hostlist installing | sort)
 for host in $installinghosts; do
   # If the host in installing have a puppet cert:
-  /opt/puppetlabs/bin/puppet cert print $host &> /dev/null
-  if [[ $? -eq 0 ]]; then
+  if /opt/puppetlabs/bin/puppet cert print "$host"; then
     logger "[PUPPET-CertClean] The host $host is reinstalling"
     # add the host to the list of certs to be revoked
     toRevoke=(${toRevoke[@]} $host)
@@ -59,16 +58,16 @@ logger "[PUPPET-CertClean] There are ${#toRevoke[@]} certificates which should b
 if [[ ${#toRevoke[@]} -gt 10 ]]; then
   logger "[PUPPET-CertClean] Aborting as there are too many certs to be revoked." 
   echo "Aborting! There are more than 10 certs shceduled for revocation:"
-  for host in ${toRevoke[@]}; do
+  for host in "${toRevoke[@]}"; do
     echo " - $host"
   done
   exit 2
 fi
 
 # Revoke the certificates identified for revokion.
-for host in ${toRevoke[@]}; do
+for host in "${toRevoke[@]}"; do
   logger "[PUPPET-CertClean] Revoking the certificate for $host" 
-  /opt/puppetlabs/bin/puppet cert clean $host
+  /opt/puppetlabs/bin/puppet cert clean "$host"
 done
 
 logger "[PUPPET-CertClean] Finished to clean puppet certificates"

--- a/files/puppet/puppetcert_clean.sh
+++ b/files/puppet/puppetcert_clean.sh
@@ -1,7 +1,7 @@
 #! /bin/bash
 
+# If this machine isnt the puppetca; we cannot clean certs...
 if [[ ! -e /etc/puppetlabs/puppet/ssl/ca/inventory.txt ]]; then
-  echo "Cannot run this script as this machine is not the puppetca"
   exit 1
 fi
 
@@ -9,14 +9,13 @@ logger "[PUPPET-CertClean] Starts to clean puppet certificates"
 
 # Get a list over all hosts registerd in shiftleader
 allslhosts=$(/opt/shiftleader/manage.py hostlist | sort)
-
-noHosts = 0
+noHosts=0
 for host in $allslhosts; do
   ((noHosts++))
 done
-
 logger "[PUPPET-CertClean] Got a list of ${noHosts} hosts from shiftleader"
 
+# If the list from shiftleader cannot be retrieved, ABORT!
 if [[ $noHosts -le 1 ]]; then
   echo "Aborting, as the list from shiftleader is too short"
   logger "[PUPPET-CertClean] Aborting, as the list from shiftleader is too short"
@@ -26,21 +25,20 @@ fi
 # Get a list over all hosts with a valid puppet client certificate
 allcahosts=$(/opt/puppetlabs/bin/puppet cert list --all | awk '{print $2}' | \
     cut -d '"' -f 2)
-
-noHosts = 0
+noHosts=0
 for host in $allcahosts; do
   ((noHosts++))
 done
-
 logger "[PUPPET-CertClean] Got a list of ${noHosts} hosts from puppetca"
 
 # Loop trough all hosts which has a puppetcert, but is not listed in
 # shiftleader:
+toRevoke=()
 for host in $(echo ${allslhosts[@]} ${allslhosts[@]} ${allcahosts[@]} | \
     tr ' ' '\n' | sort | uniq -u); do
-  logger "[PUPPET-CertClean] Deleting the cert for $host as it is not in shiftleader anymore"
-  # Delete the cert
-  /opt/puppetlabs/bin/puppet cert clean $host
+  logger "[PUPPET-CertClean] The host $host not in shiftleader anymore"
+  # add the host to the list of certs to be revoked
+  toRevoke=(${toRevoke[@]} $host)
 done
 
 # Retrieve a list over hosts in the "installing" state, and loop trough them
@@ -49,10 +47,29 @@ for host in $installinghosts; do
   # If the host in installing have a puppet cert:
   /opt/puppetlabs/bin/puppet cert print $host &> /dev/null
   if [[ $? -eq 0 ]]; then
-    logger "[PUPPET-CertClean] Deleting the cert for $host as the host is reinstalling"
-    # Delete it.
-    /opt/puppetlabs/bin/puppet cert clean $host
+    logger "[PUPPET-CertClean] The host $host is reinstalling"
+    # add the host to the list of certs to be revoked
+    toRevoke=(${toRevoke[@]} $host)
   fi
 done
 
+logger "[PUPPET-CertClean] There are ${#toRevoke[@]} certificates which should be revoked"
+
+# If there are too many certs to be revoked; abort. Large changes should need manual intervention!
+if [[ ${#toRevoke[@]} -gt 10 ]]; then
+  logger "[PUPPET-CertClean] Aborting as there are too many certs to be revoked." 
+  echo "Aborting! There are more than 10 certs shceduled for revocation:"
+  for host in ${toRevoke[@]}; do
+    echo " - $host"
+  done
+  exit 2
+fi
+
+# Revoke the certificates identified for revokion.
+for host in ${toRevoke[@]}; do
+  logger "[PUPPET-CertClean] Revoking the certificate for $host" 
+  /opt/puppetlabs/bin/puppet cert clean $host
+done
+
 logger "[PUPPET-CertClean] Finished to clean puppet certificates"
+exit 0

--- a/files/puppet/puppetcert_clean.sh
+++ b/files/puppet/puppetcert_clean.sh
@@ -23,8 +23,8 @@ if [[ $noHosts -le 1 ]]; then
 fi
 
 # Get a list over all hosts with a valid puppet client certificate
-allcahosts=$(/opt/puppetlabs/bin/puppet cert list --all | awk '{print $2}' | \
-    cut -d '"' -f 2)
+allcahosts=$(/opt/puppetlabs/bin/puppet cert list --all 2> /dev/null | \
+    awk '{print $2}' | cut -d '"' -f 2)
 noHosts=0
 for host in $allcahosts; do
   ((noHosts++))

--- a/files/vswitch/create-vswitch-lacp.sh
+++ b/files/vswitch/create-vswitch-lacp.sh
@@ -51,7 +51,7 @@ else
 fi
 
 # Set the bond to load-balance TCP streams
-ovs-vsctl set port $bond bond_mode=balance-tc
+ovs-vsctl set port $bond bond_mode=balance-tcp
 
 # In case the switch fails to negotiate LACP; fall back to regular active-backup
 # bonding.

--- a/files/vswitch/verify-vswitch-lacp.sh
+++ b/files/vswitch/verify-vswitch-lacp.sh
@@ -22,6 +22,7 @@ done
 if [[ $(ovs-appctl bond/show $bond | grep bond_mode | awk '{ print $2 }') != \
     'balance-tcp' ]]; then
   echo "The bond-type is not load-balancing"
+  exit 4
 fi
 
 exit 0

--- a/files/vswitch/verify-vswitch-lacp.sh
+++ b/files/vswitch/verify-vswitch-lacp.sh
@@ -19,4 +19,9 @@ for interface in $@; do
   fi
 done
 
+if [[ $(ovs-appctl bond/show $bond | grep bond_mode | awk '{ print $2 }') != \
+    'balance-tcp' ]]; then
+  echo "The bond-type is not load-balancing"
+fi
+
 exit 0

--- a/manifests/services/puppet/backup/ca.pp
+++ b/manifests/services/puppet/backup/ca.pp
@@ -2,6 +2,11 @@
 class profile::services::puppet::backup::ca {
   include ::profile::services::puppet::backup::folders
 
+  $adminmail = lookup('profile::admin::maillist', {
+    'value_type'    => String,
+    'default_value' => 'root',
+  }
+
   file { '/usr/local/sbin/cabackup.sh':
     ensure => present,
     owner  => 'root',
@@ -11,9 +16,10 @@ class profile::services::puppet::backup::ca {
   }
 
   cron { 'Puppet cabackup':
-    command => '/usr/local/sbin/cabackup.sh',
-    user    => 'root',
-    hour    => '13',
-    minute  => '37',
+    command     => '/usr/local/sbin/cabackup.sh',
+    environment => "MAILTO=${adminmail}",
+    hour        => '13',
+    minute      => '37',
+    user        => 'root',
   }
 }

--- a/manifests/services/puppet/backup/ca.pp
+++ b/manifests/services/puppet/backup/ca.pp
@@ -5,7 +5,7 @@ class profile::services::puppet::backup::ca {
   $adminmail = lookup('profile::admin::maillist', {
     'value_type'    => String,
     'default_value' => 'root',
-  }
+  })
 
   file { '/usr/local/sbin/cabackup.sh':
     ensure => present,

--- a/manifests/services/puppet/ca/certclean.pp
+++ b/manifests/services/puppet/ca/certclean.pp
@@ -4,7 +4,7 @@ class profile::services::puppet::ca::certclean {
   $adminmail = lookup('profile::admin::maillist', {
     'value_type'    => String,
     'default_value' => 'root',
-  }
+  })
 
   file { '/usr/local/sbin/puppetcert_clean.sh':
     ensure => present,

--- a/manifests/services/puppet/ca/certclean.pp
+++ b/manifests/services/puppet/ca/certclean.pp
@@ -1,6 +1,11 @@
 # Configures the puppetmaster to use hiera, and set up hiera replication between
 # puppet masters
 class profile::services::puppet::ca::certclean {
+  $adminmail = lookup('profile::admin::maillist', {
+    'value_type'    => String,
+    'default_value' => 'root',
+  }
+
   file { '/usr/local/sbin/puppetcert_clean.sh':
     ensure => present,
     owner  => 'root',
@@ -10,8 +15,9 @@ class profile::services::puppet::ca::certclean {
   }
 
   cron { 'Puppet cleaning certificates':
-    command => '/usr/local/sbin/puppetcert_clean.sh',
-    user    => 'root',
-    minute  => '*',
+    command     => '/usr/local/sbin/puppetcert_clean.sh',
+    environment => "MAILTO=${adminmail}",
+    minute      => '*',
+    user        => 'root',
   }
 }

--- a/manifests/services/puppet/server/hiera.pp
+++ b/manifests/services/puppet/server/hiera.pp
@@ -1,6 +1,11 @@
 # Configures the puppetmaster to use hiera, and set up hiera replication between
 # puppet masters
 class profile::services::puppet::server::hiera {
+  $adminmail = lookup('profile::admin::maillist', {
+    'value_type'    => String,
+    'default_value' => 'root',
+  }
+
   @@ssh_authorized_key { "puppetmaster-${::fqdn}":
     user    => 'root',
     type    => 'ssh-rsa',
@@ -38,15 +43,17 @@ class profile::services::puppet::server::hiera {
   }
 
   cron { 'Puppet r10k killer':
-    command => '/usr/local/sbin/killr10k.sh',
-    user    => 'root',
-    minute  => '*',
+    command     => '/usr/local/sbin/killr10k.sh',
+    environment => "MAILTO=${adminmail}",
+    minute      => '*',
+    user        => 'root',
   }
 
   cron { 'Puppet hieradata sync':
-    command => '/usr/local/sbin/pull_hiera.sh',
-    user    => 'root',
-    minute  => '*',
+    command     => '/usr/local/sbin/pull_hiera.sh',
+    environment => "MAILTO=${adminmail}",
+    minute      => '*',
+    user        => 'root',
   }
 
   file { '/root/hieradata':

--- a/manifests/services/puppet/server/hiera.pp
+++ b/manifests/services/puppet/server/hiera.pp
@@ -4,7 +4,7 @@ class profile::services::puppet::server::hiera {
   $adminmail = lookup('profile::admin::maillist', {
     'value_type'    => String,
     'default_value' => 'root',
-  }
+  })
 
   @@ssh_authorized_key { "puppetmaster-${::fqdn}":
     user    => 'root',

--- a/manifests/services/puppet/server/install.pp
+++ b/manifests/services/puppet/server/install.pp
@@ -2,7 +2,11 @@
 class profile::services::puppet::server::install {
   require ::profile::services::dashboard::install
 
-  $r10krepo = hiera('profile::puppet::r10k::repo')
+  $r10krepo = lookup('profile::puppet::r10k::repo', Stdlib::HTTPUrl)
+  $adminmail = lookup('profile::admin::maillist', {
+    'value_type'    => String,
+    'default_value' => 'root',
+  }
 
   package { 'puppetserver':
     ensure => 'present',
@@ -13,8 +17,9 @@ class profile::services::puppet::server::install {
   }
 
   cron { 'Dashboard-client puppet-environments':
-    command => '/opt/shiftleader/clients/puppetEnvReport.sh',
-    user    => 'root',
-    minute  => '*',
+    command     => '/opt/shiftleader/clients/puppetEnvReport.sh',
+    environment => "MAILTO=${adminmail}",
+    minute      => '*',
+    user        => 'root',
   }
 }

--- a/manifests/services/puppet/server/install.pp
+++ b/manifests/services/puppet/server/install.pp
@@ -6,7 +6,7 @@ class profile::services::puppet::server::install {
   $adminmail = lookup('profile::admin::maillist', {
     'value_type'    => String,
     'default_value' => 'root',
-  }
+  })
 
   package { 'puppetserver':
     ensure => 'present',


### PR DESCRIPTION
This PR fixes a couple of issues with our puppet ca service, in addition to be the first step towards having cron email us when regular work goes south.

The cron mailing brings in a new hierakey:
`profile::admin::maillist` - The email address to send notifications to

The issues solved with puppet ca is the integration with shiftleader which from time to time revokes all our certs. The new behaviour is that if more than 10 certs should be removed it needs to be done manually.