### PR TITLE
Munin-plugins for ceph and openstack

### DIFF
--- a/files/muninplugins/ceph_activity_iops
+++ b/files/muninplugins/ceph_activity_iops
@@ -1,8 +1,7 @@
 #!/bin/bash
 set -e
 
-tmpfile=$(mktemp)
-ceph insights > $tmpfile
+pools=$(ceph tell "mon.$(hostname)" report 2> /dev/null  | jq '.["osdmap"]["pools"][]' -c)
 
 if [[ $1 == "config" ]]; then
   echo "graph_title CEPH Activity - IOPS"
@@ -13,11 +12,11 @@ if [[ $1 == "config" ]]; then
   echo "graph_info Traffic to/from ceph-pools"
   echo "graph_width 550"
   
-  for pool in $(jq -c '.["df"]["pools"][]' $tmpfile); do
-    realname=$(echo $pool | jq -r '.["name"]')
+  for pool in $pools; do
+    realname=$(echo "$pool" | jq -r '.["pool_name"]')
     name=${realname//./_}
     name=${name//-/_}
-
+    
     echo "${name}write.label $realname"
     echo "${name}write.type DERIVE"
     echo "${name}write.min 0"
@@ -27,16 +26,21 @@ if [[ $1 == "config" ]]; then
     echo "${name}read.min 0"
     echo "${name}read.negative ${name}write"
   done
-  rm $tmpfile
   exit 0
 fi
 
-for pool in $(jq -c '.["df"]["pools"][]' $tmpfile); do
-  name=$(echo $pool | jq -r '.["name"]')
+declare -A poolids
+for pool in $pools; do
+  poolids[$(echo "$pool" | jq -r '.["pool"]')]=$(echo "$pool" | jq -r '.["pool_name"]')
+done
+
+for data in $(ceph tell "mon.$(hostname)" report 2> /dev/null  | jq '.["pool_stats"][]' -c); do
+  name=${poolids[$(echo "$data" | jq -r '.["poolid"]')]}
   name=${name//./_}
   name=${name//-/_}
   
-  echo ${name}write.value $(echo $pool | jq '.["stats"]["wr"]')
-  echo ${name}read.value $(echo $pool | jq '.["stats"]["rd"]')
+  iowrite=$(echo "$data" | jq '.["stat_sum"]["num_write"]')
+  ioread=$(echo "$data" | jq '.["stat_sum"]["num_read"]')
+  echo "${name}write.value ${iowrite}"
+  echo "${name}read.value ${ioread}"
 done
-rm $tmpfile

--- a/files/muninplugins/ceph_activity_traffic
+++ b/files/muninplugins/ceph_activity_traffic
@@ -1,8 +1,7 @@
 #!/bin/bash
 set -e
 
-tmpfile=$(mktemp)
-ceph insights > $tmpfile
+pools=$(ceph tell "mon.$(hostname)" report 2> /dev/null  | jq '.["osdmap"]["pools"][]' -c)
 
 if [[ $1 == "config" ]]; then
   echo "graph_title CEPH Activity - Bits read/written"
@@ -13,11 +12,11 @@ if [[ $1 == "config" ]]; then
   echo "graph_info Read and write traffic to ceph-pools"
   echo "graph_width 550"
   
-  for pool in $(jq -c '.["df"]["pools"][]' $tmpfile); do
-    realname=$(echo $pool | jq -r '.["name"]')
+  for pool in $pools; do
+    realname=$(echo "$pool" | jq -r '.["pool_name"]')
     name=${realname//./_}
     name=${name//-/_}
-
+    
     echo "${name}write.label $realname"
     echo "${name}write.type DERIVE"
     echo "${name}write.min 0"
@@ -27,19 +26,21 @@ if [[ $1 == "config" ]]; then
     echo "${name}read.min 0"
     echo "${name}read.negative ${name}write"
   done
-  rm $tmpfile
   exit 0
 fi
 
-for pool in $(jq -c '.["df"]["pools"][]' $tmpfile); do
-  name=$(echo $pool | jq -r '.["name"]')
+declare -A poolids
+for pool in $pools; do
+  poolids[$(echo "$pool" | jq -r '.["pool"]')]=$(echo "$pool" | jq -r '.["pool_name"]')
+done
+
+for data in $(ceph tell "mon.$(hostname)" report 2> /dev/null  | jq '.["pool_stats"][]' -c); do
+  name=${poolids[$(echo "$data" | jq -r '.["poolid"]')]}
   name=${name//./_}
   name=${name//-/_}
   
-  wr=$(echo $pool | jq '.["stats"]["wr_bytes"]')
-  rd=$(echo $pool | jq '.["stats"]["rd_bytes"]')
-  echo ${name}write.value $(echo "$wr * 8" | bc)
-  echo ${name}read.value $(echo "$rd * 8" | bc)
+  kbwrite=$(echo "$data" | jq '.["stat_sum"]["num_write_kb"]')
+  kbread=$(echo "$data" | jq '.["stat_sum"]["num_read_kb"]')
+  echo "${name}write.value $(echo "$kbwrite * 1024 * 8" | bc)"
+  echo "${name}read.value $(echo "$kbread * 1024 * 8" | bc)"
 done
-
-rm $tmpfile

--- a/files/muninplugins/ceph_objects
+++ b/files/muninplugins/ceph_objects
@@ -1,8 +1,7 @@
 #!/bin/bash
 set -e
 
-tmpfile=$(mktemp)
-ceph insights > $tmpfile
+pools=$(ceph tell "mon.$(hostname)" report 2> /dev/null  | jq '.["osdmap"]["pools"][]' -c)
 
 if [[ $1 == "config" ]]; then
   echo "graph_title CEPH Objects"
@@ -12,24 +11,26 @@ if [[ $1 == "config" ]]; then
   echo "graph_scale yes"
   echo "graph_info The number of objects in each ceph pool"
   
-  for pool in $(jq -c '.["df"]["pools"][]' $tmpfile); do
-    name=$(echo $pool | jq -r '.["name"]')
-    name=${name//-/_}
+  for pool in $pools; do
+    name=$(echo "$pool" | jq -r '.["pool_name"]')
     name=${name//./_}
+    name=${name//-/_}
     
-    echo ${name}.label $(echo $pool | jq -r '.["name"]')
-    echo ${name}.info Objects in the $(echo $pool | jq -r '.["name"]') pool.
+    echo "${name}.label $(echo "$pool" | jq -r '.["pool_name"]')"
+    echo "${name}.info Objects in the $(echo "$pool" | jq -r '.["pool_name"]') pool."
   done
-  rm $tmpfile
   exit 0
 fi
 
-for pool in $(jq -c '.["df"]["pools"][]' $tmpfile); do
-  name=$(echo $pool | jq -r '.["name"]')
+declare -A poolids
+for pool in $pools; do
+  poolids[$(echo "$pool" | jq -r '.["pool"]')]=$(echo "$pool" | jq -r '.["pool_name"]')
+done
+
+for data in $(ceph tell "mon.$(hostname)" report 2> /dev/null | jq '.["pool_stats"][]' -c); do
+  name=${poolids[$(echo "$data" | jq -r '.["poolid"]')]}
   name=${name//./_}
   name=${name//-/_}
   
-  echo ${name}.value $(echo $pool | jq '.["stats"]["objects"]')
+  echo "${name}.value $(echo "$data" | jq '.["stat_sum"]["num_objects"]')"
 done
-
-rm $tmpfile

--- a/files/muninplugins/ceph_osd
+++ b/files/muninplugins/ceph_osd
@@ -21,18 +21,15 @@ osds=0
 ups=0
 ins=0
 
-while read -r osd; do
-  up=$(echo $osd | jq '.["up"]')
-  in=$(echo $osd | jq '.["in"]')
-
-  osds=$((osds + 1))
-  if [ $up -eq 1 ]; then
-    ups=$((ups + 1))
-  fi
-  if [ $in -eq 1 ]; then
-    ins=$((ins + 1))
-  fi
-done < <(ceph insights | jq -c '.["osd_dump"]["osds"][]') 
+for osd in $(ceph tell "mon.$(hostname)" report 2> /dev/null  | jq '.["osdmap"]["osds"][]' -c); do
+  ((osds += 1))
+  if [[ $(echo "$osd" | jq -r '.["up"]') -eq '1' ]]; then
+    ((ups += 1))
+  fi 
+  if [[ $(echo "$osd" | jq -r '.["in"]') -eq '1' ]]; then
+    ((ins += 1))
+  fi 
+done
 
 echo "osds.value $osds" 
 echo "up.value $ups" 

--- a/files/muninplugins/ceph_pg
+++ b/files/muninplugins/ceph_pg
@@ -1,0 +1,31 @@
+#!/bin/bash
+set -e
+
+pools=$(ceph tell "mon.$(hostname)"  report 2> /dev/null  | jq '.["osdmap"]["pools"][]' -c)
+
+if [[ $1 == "config" ]]; then
+  echo "graph_title CEPH PG's"
+  echo "graph_category ceph"
+  echo "graph_vlabel PG's"
+  echo "graph_args -l 0"
+  echo "graph_scale yes"
+  echo "graph_info The number of placement groups in each ceph pool"
+  
+  for pool in $pools; do
+    name=$(echo "$pool" | jq -r '.["pool_name"]')
+    name=${name//./_}
+    name=${name//-/_}
+    
+    echo "${name}.label $(echo "$pool" | jq -r '.["pool_name"]')"
+    echo "${name}.info Objects in the $(echo "$pool" | jq -r '.["pool_name"]') pool."
+  done
+  exit 0
+fi
+
+for pool in $pools; do
+  name=$(echo "$pool" | jq -r '.["pool_name"]')
+  name=${name//./_}
+  name=${name//-/_}
+
+  echo "${name}.value $(echo "$pool" | jq -r '.["pg_num"]')"
+done

--- a/files/muninplugins/ceph_storage
+++ b/files/muninplugins/ceph_storage
@@ -1,8 +1,7 @@
 #!/bin/bash
 set -e
 
-tmpfile=$(mktemp)
-ceph insights > $tmpfile
+pools=$(ceph tell "mon.$(hostname)" report 2> /dev/null  | jq '.["osdmap"]["pools"][]' -c)
 
 if [[ $1 == "config" ]]; then
   echo "graph_title CEPH Storage"
@@ -12,24 +11,26 @@ if [[ $1 == "config" ]]; then
   echo "graph_scale yes"
   echo "graph_info The number of bytes in each ceph pool"
   
-  for pool in $(jq -c '.["df"]["pools"][]' $tmpfile); do
-    name=$(echo $pool | jq -r '.["name"]')
+  for pool in $pools; do
+    name=$(echo "$pool" | jq -r '.["pool_name"]')
     name=${name//./_}
     name=${name//-/_}
     
-    echo ${name}.label $(echo $pool | jq -r '.["name"]')
-    echo ${name}.info Objects in the $(echo $pool | jq -r '.["name"]') pool.
+    echo "${name}.label $(echo "$pool" | jq -r '.["pool_name"]')"
+    echo "${name}.info Bytes in the $(echo "$pool" | jq -r '.["pool_name"]') pool."
   done
-  rm $tmpfile
   exit 0
 fi
 
-for pool in $(jq -c '.["df"]["pools"][]' $tmpfile); do
-  name=$(echo $pool | jq -r '.["name"]')
+declare -A poolids
+for pool in $pools; do
+  poolids[$(echo "$pool" | jq -r '.["pool"]')]=$(echo "$pool" | jq -r '.["pool_name"]')
+done
+
+for data in $(ceph tell "mon.$(hostname)" report 2> /dev/null  | jq '.["pool_stats"][]' -c); do
+  name=${poolids[$(echo "$data" | jq -r '.["poolid"]')]}
   name=${name//./_}
   name=${name//-/_}
   
-  echo ${name}.value $(echo $pool | jq '.["stats"]["bytes_used"]')
+  echo "${name}.value $(echo "$data" | jq '.["stat_sum"]["num_bytes"]')"
 done
-
-rm $tmpfile

--- a/files/muninplugins/ceph_total
+++ b/files/muninplugins/ceph_total
@@ -14,11 +14,11 @@ if [[ $1 == "config" ]]; then
   exit 0
 fi
 
-tmpfile=$(mktemp)
-ceph insights > $tmpfile
+data=$(ceph tell "mon.$(hostname)" report 2> /dev/null  | jq -c '.["osd_sum"]["statfs"]')
 
-echo "capacity.value $(cat $tmpfile | jq '.["df"]["stats"]["total_bytes"]')"
-echo "free.value $(cat $tmpfile | jq '.["df"]["stats"]["total_avail_bytes"]')"
-echo "data.value $(cat $tmpfile | jq '.["df"]["stats"]["total_used_raw_bytes"]')"
+size=$(echo "$data" | jq '.["total"]')
+free=$(echo "$data" | jq '.["available"]')
 
-rm $tmpfile
+echo "capacity.value $size"
+echo "free.value $free"
+echo "data.value $((size-free))"

--- a/files/muninplugins/haproxy_ng
+++ b/files/muninplugins/haproxy_ng
@@ -1,0 +1,542 @@
+#!/usr/bin/perl -w
+#
+# haproxy_ng - Munin plugin HAProxy
+# Copyright (C) 2012 Redpill Linpro AS
+#
+# Author: Trygve Vea <tv@redpill-linpro.com>
+# 
+# Updates: Eigil Obrestad <eigil.obrestad@ntnu.no>
+#          2020.02.13 - Add graphs for que/connect/response/total time.
+# 
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+# 
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+# 
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Graph stats from the haproxy daemon
+#
+# Parameters supported:
+#
+#     config
+#
+# Configurable variables
+#
+#     url      - Override default status-url
+#     username - Basic authentication username
+#     password - Basic authentication password
+#
+# Example:
+#
+#   [haproxy_backend]
+#   env.url http://backend.example.com/haproxy-status;csv;norefresh
+#   env.username monitor
+#   env.password somepasswordorother
+#
+# Magic markers:
+#%# family=contrib
+
+use Munin::Plugin;
+
+need_multigraph();
+
+my $ret = undef;
+if (! eval "require LWP::UserAgent;")
+{
+    $ret = "LWP::UserAgent not found";
+}
+
+my $URL = exists $ENV{'url'} ? $ENV{'url'} : "http://localhost/haproxy-status;csv;norefresh";
+
+{
+    package MyLWP;
+    @ISA = qw(LWP::UserAgent);
+
+    sub new {
+        my $self = LWP::UserAgent::new(@_);
+        $self;
+    }
+    sub get_basic_credentials {
+        return ($ENV{"username"}, $ENV{"password"});
+    }
+}
+
+my $ua = MyLWP->new(timeout => 30);
+
+my @types = qw(frontend backend server);
+my $url = $URL;
+my $response = $ua->request(HTTP::Request->new('GET',$url));
+my $content = $response->content;
+my $set;
+my @columns;
+
+my %datas = ();
+
+my @graph_parameters = ('total','order','scale','vlabel','args', 'category');
+my @field_parameters = ('graph', 'min', 'max', 'draw', 'cdef', 'warning', 'colour', 'info', 'type', 'negative');
+
+my %aspects = (
+    'Bandwidth' => {
+        'title' => 'Bandwidth usage',
+        'category' => 'HAProxy',
+        'vlabel' => 'per second',
+        'values' => {
+            'bin' => {
+                'type' => 'DERIVE',
+                'min' => 0,
+                'graph' => 'no'
+            },
+            'bout' => {
+                'type' => 'DERIVE',
+                'draw' => 'AREASTACK',
+                'min' => 0,
+                'label' => 'bytes',
+                'info' => 'Bytes transferred',
+                'negative' => 'bin'
+            }
+        }
+    },
+    'Sessions' => {
+        'title' => 'Sessions',
+        'category' => 'HAProxy',
+        'vlabel' => 'current',
+        'values' => {
+            'scur' => {
+                'type' => 'GAUGE',
+                'draw' => 'AREASTACK',
+                'min' => 0,
+                'label' => 'sessions',
+                'info' => 'Current sessions',
+            }
+        }
+    },
+    'SessionRate' => {
+        'title' => 'SessionRate',
+        'category' => 'HAProxy',
+        'vlabel' => 'current',
+        'values' => {
+            'stot' => {
+                'type' => 'DERIVE',
+                'draw' => 'AREASTACK',
+                'min' => 0,
+                'label' => 'sessions',
+                'info' => 'sessions',
+            }
+        }
+    },
+    'Uptime' => {
+        'title' => 'Uptime',
+        'category' => 'HAProxy',
+        'vlabel' => 'seconds',
+        'values' => {
+            'lastchg' => {
+                'type' => 'GAUGE',
+                'draw' => 'LINE2',
+                'min' => 0,
+                'label' => 'seconds',
+                'info' => 'Seconds',
+            }
+        }
+    },
+    'Active' => {
+        'title' => 'Active Servers',
+        'category' => 'HAProxy',
+        'vlabel' => 'servers',
+        'values' => {
+            'act' => {
+                'type' => 'GAUGE',
+                'draw' => 'LINE2',
+                'min' => 0,
+                'label' => 'servers',
+                'info' => 'Number of active servers'
+            }
+        }
+    },
+    'ErrorReq' => {
+        'title' => 'Request errors',
+        'category' => 'HAProxy',
+        'vlabel' => 'per second',
+        'values' => {
+            'ereq' => {
+                'type' => 'DERIVE',
+                'draw' => 'LINE2',
+                'min' => 0,
+                'label' => 'requests',
+                'info' => 'Number of request errors'
+            }
+        }
+    },
+    'ErrorResp' => {
+        'title' => 'Response errors',
+        'category' => 'HAProxy',
+        'vlabel' => 'per second',
+        'values' => {
+            'eresp' => {
+                'type' => 'DERIVE',
+                'draw' => 'LINE2',
+                'min' => 0,
+                'label' => 'requests',
+                'info' => 'Number of response errors'
+            }
+        }
+    },
+    'QueueTime' => {
+        'title' => 'Queue Time',
+        'category' => 'HAProxy',
+        'vlabel' => 'ms',
+        'values' => {
+            'qtime' => {
+                'type' => 'DERIVE',
+                'draw' => 'LINE2',
+                'min' => 0,
+                'label' => 'ms',
+                'info' => 'Request queuetime'
+            }
+        }
+    },
+    'ConnectTime' => {
+        'title' => 'Connect Time',
+        'category' => 'HAProxy',
+        'vlabel' => 'ms',
+        'values' => {
+            'ctime' => {
+                'type' => 'DERIVE',
+                'draw' => 'LINE2',
+                'min' => 0,
+                'label' => 'ms',
+                'info' => 'Request connect time'
+            }
+        }
+    },
+    'ResponseTime' => {
+        'title' => 'Response Time',
+        'category' => 'HAProxy',
+        'vlabel' => 'ms',
+        'values' => {
+            'rtime' => {
+                'type' => 'DERIVE',
+                'draw' => 'LINE2',
+                'min' => 0,
+                'label' => 'ms',
+                'info' => 'Request response time'
+            }
+        }
+    },
+    'TotalTime' => {
+        'title' => 'Total Time',
+        'category' => 'HAProxy',
+        'vlabel' => 'ms',
+        'values' => {
+            'ttime' => {
+                'type' => 'DERIVE',
+                'draw' => 'LINE2',
+                'min' => 0,
+                'label' => 'ms',
+                'info' => 'Total time'
+            }
+        }
+    }
+);
+
+my %graphs = (
+    'BandwidthFront' => {
+        'lines' => 'frontend',
+        'title' => 'Bandwidth usage by Frontend',
+        'aspect' => 'Bandwidth'
+    },
+    'BandwidthBack' => {
+        'lines' => 'backend',
+        'title' => 'Bandwidth usage by Backend',
+        'aspect' => 'Bandwidth',
+    },
+    'BandwidthBack.BACKEND' => {
+        'lines' => 'server',
+        'title' => 'Bandwidth usage by backend: BACKEND',
+        'aspect' => 'Bandwidth',
+    },
+    'SessionsFront' => {
+        'lines' => 'frontend',
+        'title' => 'Current Sessions by Frontend',
+        'aspect' => 'Sessions'
+    },
+    'SessionsBack' => {
+        'lines' => 'backend',
+        'title' => 'Current Sessions by Backend',
+        'aspect' => 'Sessions'
+    },
+    'SessionsBack.BACKEND' => {
+        'lines' => 'server',
+        'title' => 'Current Sessions by backend: BACKEND',
+        'aspect' => 'Sessions'
+    },
+    'SessionRateFront' => {
+        'lines' => 'frontend',
+        'title' => 'Session rate by Frontend',
+        'aspect' => 'SessionRate'
+    },
+    'SessionRateBack' => {
+        'lines' => 'backend',
+        'title' => 'Session rate by Backend',
+        'aspect' => 'SessionRate'
+    },
+    'SessionRateBack.BACKEND' => {
+        'lines' => 'server',
+        'title' => 'Session rate by backend: BACKEND',
+        'aspect' => 'SessionRate'
+    },
+    'Uptime' => {
+        'lines' => 'backend',
+        'title' => 'Uptime by Backend',
+        'aspect' => 'Uptime'
+    },
+    'Uptime.BACKEND' => {
+        'lines' => 'server',
+        'title' => 'Uptime by servers in BACKEND',
+        'aspect' => 'Uptime'
+    },
+    'Active' => {
+        'lines' => 'backend',
+        'title' => 'Active servers by Backend',
+        'aspect' => 'Active'
+    },
+    'ErrorsFront' => {
+        'lines' => 'frontend',
+        'title' => 'Request errors by Frontend',
+        'aspect' => 'ErrorReq'
+    },
+    'ErrorsBack' => {
+        'lines' => 'backend',
+        'title' => 'Response errors by Backend',
+        'aspect' => 'ErrorResp'
+    },
+    'ErrorsBack.BACKEND' => {
+        'lines' => 'server',
+        'title' => 'Response errors by backend: BACKEND',
+        'aspect' => 'ErrorResp'
+    },
+    'QueueTime' => {
+        'lines' => 'backend',
+        'title' => 'Queue-time by Backend',
+        'aspect' => 'QueueTime'
+    },
+    'QueueTime.BACKEND' => {
+        'lines' => 'server',
+        'title' => 'Queue-time by backend: BACKEND',
+        'aspect' => 'QueueTime'
+    },
+    'ConnectTime' => {
+        'lines' => 'backend',
+        'title' => 'Connect-time by Backend',
+        'aspect' => 'ConnectTime'
+    },
+    'ConnectTime.BACKEND' => {
+        'lines' => 'server',
+        'title' => 'Connect-time by backend: BACKEND',
+        'aspect' => 'ConnectTime'
+    },
+    'ResponseTime' => {
+        'lines' => 'backend',
+        'title' => 'Response-time by Backend',
+        'aspect' => 'ResponseTime'
+    },
+    'ResponseTime.BACKEND' => {
+        'lines' => 'server',
+        'title' => 'Response-time by backend: BACKEND',
+        'aspect' => 'ResponseTime'
+    },
+    'TotalTime' => {
+        'lines' => 'backend',
+        'title' => 'Total-time by Backend',
+        'aspect' => 'TotalTime'
+    },
+    'TotalTime.BACKEND' => {
+        'lines' => 'server',
+        'title' => 'Total-time by backend: BACKEND',
+        'aspect' => 'TotalTime'
+    }
+);
+
+my @lines = split(/\n/,$content);
+
+foreach ( @lines )
+{
+    my $i = 0;
+    my @line = split(/,/,$_);
+    if ( !$set )
+    {
+        $set++;
+        @columns = @line;
+        $columns[0] =~ s/^# //;
+        next;
+    }
+
+    foreach(@line)
+    {
+        $datas{$types[$line[32]]}{$line[0]}{$line[1]}{$columns[$i]} = $_;
+        $i++;
+    }
+}
+
+sub fetch_graph
+{
+    my $name = shift;
+    my $graphkey = shift;
+    my @names = split(/\./,$name);
+    my $backend = $names[1];
+    my $data;
+    my $aspect = $graphs{$graphkey}{'aspect'};
+
+    print "multigraph HAP$name\n";
+
+    if(!defined $ARGV[0]){ $data = 'values'; }
+    elsif ( $ARGV[0] eq 'config' ) { $data = 'config' }
+
+
+    if ( $data eq 'config' ) {
+        my $title = $graphs{$graphkey}{'title'};
+        $title =~ s/BACKEND/$backend/g;
+
+        print "graph_title $title\n";
+        foreach (@graph_parameters) {
+            if (!defined($aspects{$aspect}{$_})) {
+                next;
+            }
+            print "graph_$_ $aspects{$aspect}{$_}\n";
+        }
+    }
+
+    foreach $val (sort keys %{$aspects{$aspect}{'values'}}) {
+        if ( $graphs{$graphkey}{'lines'} eq 'frontend' )
+        {
+            foreach $fe ( sort keys %{$datas{'frontend'}} )
+            {
+                if ( $data eq 'config' ) {
+                    print $fe."_$val.label $fe\n";
+                    foreach (@field_parameters) {
+                        if (!defined($aspects{$aspect}{'values'}{$val}{$_})) {
+                            next;
+                        }
+                        if ( $_ eq 'negative' )
+                        {
+                            print $fe."_$val.$_ $fe"."_$aspects{$aspect}{'values'}{$val}{$_}\n";
+                        }
+                        else
+                        {
+                            print $fe."_$val.$_ $aspects{$aspect}{'values'}{$val}{$_}\n";
+                        }
+                    }
+                }
+                else {
+                    if ( $val eq 'lastchg' and $datas{'frontend'}{$fe}{'FRONTEND'}{'status'} eq 'DOWN' ) {
+                        print $fe."_".$val.".value 0\n";
+                    }
+                    else {
+                        print $fe."_".$val.".value ".$datas{'frontend'}{$fe}{'FRONTEND'}{$val}."\n";
+                    }
+                }
+            }
+        }
+        elsif ( $graphs{$graphkey}{'lines'} eq 'backend' )
+        {
+            foreach $be ( sort keys %{$datas{'backend'}} )
+            {
+                if ( $data eq 'config' ) {
+                    print $be."_$val.label $be\n";
+                    foreach (@field_parameters) {
+                        if (!defined($aspects{$aspect}{'values'}{$val}{$_})) {
+                            next;
+                        }
+                        if ( $_ eq 'negative' )
+                        {
+                            print $be."_$val.$_ $be"."_$aspects{$aspect}{'values'}{$val}{$_}\n";
+                        }
+                        else
+                        {
+                            print $be."_$val.$_ $aspects{$aspect}{'values'}{$val}{$_}\n";
+                        }
+                    }
+                }
+                else {
+                    if ( $val eq 'lastchg' and $datas{'backend'}{$be}{'BACKEND'}{'status'} eq 'DOWN' ) {
+                        print $be."_".$val.".value 0\n";
+                    }
+                    else {
+                        print $be."_".$val.".value ".$datas{'backend'}{$be}{'BACKEND'}{$val}."\n";
+                    }
+                }
+            }
+        }
+        elsif ( $graphs{$graphkey}{'lines'} eq 'server' )
+        {
+            foreach $server ( sort keys %{$datas{'server'}{$backend}} )
+            {
+                if ( $data eq 'config' ) {
+                    print $server."_$val.label $server\n";
+                    foreach (@field_parameters) {
+                        if (!defined($aspects{$aspect}{'values'}{$val}{$_})) {
+                            next;
+                        }
+                        if ( $_ eq 'negative' )
+                        {
+                            print $server."_$val.$_ $server"."_$aspects{$aspect}{'values'}{$val}{$_}\n";
+                        }
+                        else
+                        {
+                            print $server."_$val.$_ $aspects{$aspect}{'values'}{$val}{$_}\n";
+                        }
+                    }
+                }
+                else {
+                    if ( $val eq 'lastchg' and $datas{'server'}{$backend}{$server}{'status'} eq 'DOWN' ) {
+                        print $server."_".$val.".value 0\n";
+                    }
+                    else {
+                        print $server."_".$val.".value ".$datas{'server'}{$backend}{$server}{$val}."\n";
+                    }
+                }
+            }
+        }
+    }
+    print "\n";
+}
+
+sub proc_graph
+{
+    my $g = shift;
+    my $pre = shift;
+    my $level = shift;
+
+    foreach( sort keys %{$g} )
+    {
+        my $name = $_;
+        my @spects = split(/\./,$name);
+        my $aspect = $spects[0];
+        my $graphkey = $name;
+
+        if ( $name =~ /BACKEND/ )
+        {
+            foreach $be (sort keys %{$datas{'backend'}})
+            {
+                my $name = $name;
+                $name =~ s/BACKEND/$be/;
+                fetch_graph($name, $graphkey, $be);
+            }
+        }
+        else
+        {
+            fetch_graph($name, $graphkey);
+        }
+    }
+}
+
+proc_graph(\%graphs, "", 0);
+
+# vim:syntax=perl

--- a/files/muninplugins/openstack_ipuse
+++ b/files/muninplugins/openstack_ipuse
@@ -15,7 +15,7 @@ if [[ $1 == "config" ]]; then
 fi
 
 for net in $EXTERNALS; do
-  value=$(openstack ip availability show $net -f value -c subnet_ip_availability)
+  value=$(openstack ip availability show $net -f value -c subnet_ip_availability | grep "ip_version='4'")
 
   [[ $value =~ total_ips=\'([0-9]+)\' ]]
   total=${BASH_REMATCH[1]}

--- a/files/muninplugins/openstack_ipuse_
+++ b/files/muninplugins/openstack_ipuse_
@@ -17,7 +17,7 @@ if [[ $1 == "config" ]]; then
   exit 0
 fi
 
-value=$(openstack ip availability show $net -f value -c subnet_ip_availability)
+value=$(openstack ip availability show $net -f value -c subnet_ip_availability | grep "ip_version='4'")
 [[ $value =~ total_ips=\'([0-9]+)\' ]]
 echo "total.value ${BASH_REMATCH[1]}"
 

--- a/files/muninplugins/openstack_neutron_nstypes
+++ b/files/muninplugins/openstack_neutron_nstypes
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+types=$(ip netns ls | cut -d '-' -f 1 | sort | uniq)
+
+if [[ $1 == "config" ]]; then
+  echo "graph_title Neutron resources"
+  echo "graph_category openstack"
+  echo "graph_vlabel Instances"
+  echo "graph_args -l 0"
+  echo "graph_scale yes"
+  echo "graph_info Amount of services on the neutron-node"
+  for t in $types; do 
+    echo "${t}.label ${t}"
+    echo "${t}.info Number of ${t} namespaces"
+  done
+  exit 0
+fi
+
+for t in $types; do 
+  echo "${t}.value $(ip netns ls | grep -c "$t")"
+done

--- a/files/muninplugins/openstack_os_images
+++ b/files/muninplugins/openstack_os_images
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+if [[ $1 == "config" ]]; then
+  echo "graph_title Glance OS types"
+  echo "graph_category openstack"
+  echo "graph_vlabel #"
+  echo "graph_args -l 0"
+  echo "graph_scale yes"
+  echo "graph_info Amount of images featuring a certain OS"
+
+  while read -r name; do
+    label=${name// /_}
+    label=${label//./_}
+    echo "${label}.label ${name}"
+  done < <(openstack image list -c Name -f value  | \
+    grep -Eo '(Ubuntu\ (Server\ )?[0-9]{2}.[0-9]{2}|CentOS\ [0-9](\.[0-9])?|Windows\ (Server\ )?[0-9]+|Debian\ [0-9]+|Kali)' | sort | uniq)
+
+  exit 0
+fi
+
+while read -r line; do
+  no=$(echo "$line" | awk '{ print $1 }')
+  name=$(echo "$line" | awk '{for (i=2; i<NF; i++) printf $i " "; print $NF}')
+  label=${name// /_}
+  label=${label//./_}
+
+  echo "${label}.value ${no}"
+done < <(openstack image list -c Name -f value  | \
+  grep -Eo '(Ubuntu\ (Server\ )?[0-9]{2}.[0-9]{2}|CentOS\ [0-9](\.[0-9])?|Windows\ (Server\ )?[0-9]+|Debian\ [0-9]+|Kali)' | sort | uniq -c)

--- a/files/muninplugins/openstack_os_instances
+++ b/files/muninplugins/openstack_os_instances
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+if [[ $1 == "config" ]]; then
+  echo "graph_title VM OS types"
+  echo "graph_category openstack"
+  echo "graph_vlabel #"
+  echo "graph_args -l 0"
+  echo "graph_scale yes"
+  echo "graph_info Amount of virtual machines featuring a certain OS"
+
+  while read -r name; do
+    label=${name// /_}
+    label=${label//./_}
+    echo "${label}.label ${name}"
+  done < <(openstack server list -c Image -f value --all  | \
+    grep -Eo '(Ubuntu\ (Server\ )?[0-9]{2}.[0-9]{2}|CentOS\ [0-9](\.[0-9])?|Windows\ (Server\ )?[0-9]+|Debian\ [0-9]+|Kali)' | sort | uniq)
+
+  exit 0
+fi
+
+while read -r line; do
+  no=$(echo "$line" | awk '{ print $1 }')
+  name=$(echo "$line" | awk '{for (i=2; i<NF; i++) printf $i " "; print $NF}')
+  label=${name// /_}
+  label=${label//./_}
+
+  echo "${label}.value ${no}"
+done < <(openstack server list -c Image -f value --all | \
+  grep -Eo '(Ubuntu\ (Server\ )?[0-9]{2}.[0-9]{2}|CentOS\ [0-9](\.[0-9])?|Windows\ (Server\ )?[0-9]+|Debian\ [0-9]+|Kali)' | sort | uniq -c)

--- a/manifests/ceph/monitoring/pool.pp
+++ b/manifests/ceph/monitoring/pool.pp
@@ -6,7 +6,7 @@ define profile::ceph::monitoring::pool {
   include ::profile::systemd::reload
 
   $collectors = lookup('profile::monitoring::ceph::collectors', {
-    'default_value' => true,
+    'default_value' => false,
   })
 
   if($collectors) {

--- a/manifests/monitoring/munin/plugin/ceph.pp
+++ b/manifests/monitoring/munin/plugin/ceph.pp
@@ -4,11 +4,6 @@ class profile::monitoring::munin::plugin::ceph {
   require ::profile::monitoring::munin::plugin::ceph::base
 
   # Add general ceph-related graphs.
-  munin::plugin { 'ceph_total':
-    ensure => present,
-    source => 'puppet:///modules/profile/muninplugins/ceph_total',
-    config => ['user root'],
-  }
   munin::plugin { 'ceph_objects':
     ensure => present,
     source => 'puppet:///modules/profile/muninplugins/ceph_objects',
@@ -19,9 +14,19 @@ class profile::monitoring::munin::plugin::ceph {
     source => 'puppet:///modules/profile/muninplugins/ceph_osd',
     config => ['user root'],
   }
+  munin::plugin { 'ceph_pg':
+    ensure => present,
+    source => 'puppet:///modules/profile/muninplugins/ceph_pg',
+    config => ['user root'],
+  }
   munin::plugin { 'ceph_storage':
     ensure => present,
     source => 'puppet:///modules/profile/muninplugins/ceph_storage',
+    config => ['user root'],
+  }
+  munin::plugin { 'ceph_total':
+    ensure => present,
+    source => 'puppet:///modules/profile/muninplugins/ceph_total',
     config => ['user root'],
   }
 

--- a/manifests/monitoring/munin/plugin/glance.pp
+++ b/manifests/monitoring/munin/plugin/glance.pp
@@ -1,0 +1,29 @@
+# This class installs the munin-plugins for monitoring status of glance
+class profile::monitoring::munin::plugin::glance {
+  include ::ntnuopenstack::clients
+
+  $keystone_location = lookup('ntnuopenstack::keystone::endpoint::internal', {
+    'value_type' => Stdlib::Httpurl,
+  })
+  $keystone_url = "${keystone_location}:5000/v3"
+
+  $admin_username = lookup('ntnuopenstack::keystone::admin_username', {
+    'value_type'    => String,
+    'default_value' => 'admin',
+  })
+  $admin_pass = lookup('ntnuopenstack::keystone::admin_password', {
+    'value_type' => String,
+  })
+
+  munin::plugin { 'openstack_os_images':
+    ensure => present,
+    source => 'puppet:///modules/profile/muninplugins/openstack_os_images',
+    config => [ 'user glance',
+      'env.OS_PROJECT_NAME admin',
+      "env.OS_USERNAME ${admin_username}",
+      "env.OS_PASSWORD ${admin_pass}",
+      "env.OS_AUTH_URL ${keystone_url}",
+      'env.OS_IDENTITY_API_VERSION 3',
+    ],
+  }
+}

--- a/manifests/monitoring/munin/plugin/haproxy.pp
+++ b/manifests/monitoring/munin/plugin/haproxy.pp
@@ -9,6 +9,7 @@ class profile::monitoring::munin::plugin::haproxy {
   
   munin::plugin { "haproxy_ng":
     ensure => link,
+    source => 'puppet:///modules/profile/muninplugins/haproxy_ng',
     config => ['env.url http://localhost:9000/haproxy-status;csv;norefresh'],
   }
 }

--- a/manifests/monitoring/munin/plugin/haproxy.pp
+++ b/manifests/monitoring/munin/plugin/haproxy.pp
@@ -8,7 +8,7 @@ class profile::monitoring::munin::plugin::haproxy {
   )
   
   munin::plugin { "haproxy_ng":
-    ensure => link,
+    ensure => present,
     source => 'puppet:///modules/profile/muninplugins/haproxy_ng',
     config => ['env.url http://localhost:9000/haproxy-status;csv;norefresh'],
   }

--- a/manifests/monitoring/munin/plugin/keystone.pp
+++ b/manifests/monitoring/munin/plugin/keystone.pp
@@ -1,0 +1,29 @@
+# This class installs munin-plugins for our keystone-nodes
+class profile::monitoring::munin::plugin::keystone {
+  include ::ntnuopenstack::clients
+
+  $keystone_location = lookup('ntnuopenstack::keystone::endpoint::internal', {
+    'value_type' => Stdlib::Httpurl,
+  })
+  $keystone_url = "${keystone_location}:5000/v3"
+
+  $admin_username = lookup('ntnuopenstack::keystone::admin_username', {
+    'value_type'    => String,
+    'default_value' => 'admin',
+  })
+  $admin_pass = lookup('ntnuopenstack::keystone::admin_password', {
+    'value_type' => String,
+  })
+
+  munin::plugin { 'openstack_projects':
+    ensure => present,
+    source => 'puppet:///modules/profile/muninplugins/openstack_projects',
+    config => [ 'user keystone',
+      'env.OS_PROJECT_NAME admin',
+      "env.OS_USERNAME ${admin_username}",
+      "env.OS_PASSWORD ${admin_pass}",
+      "env.OS_AUTH_URL ${keystone_url}",
+      'env.OS_IDENTITY_API_VERSION 3',
+    ],
+  }
+}

--- a/manifests/monitoring/munin/plugin/neutronapi.pp
+++ b/manifests/monitoring/munin/plugin/neutronapi.pp
@@ -1,0 +1,64 @@
+# This class installs relevant munin-plugins for our neutronapi-nodes
+class profile::monitoring::munin::plugin::neutronapi {
+  include ::ntnuopenstack::clients
+
+  $keystone_location = lookup('ntnuopenstack::keystone::endpoint::internal', {
+    'value_type' => Stdlib::Httpurl,
+  })
+  $keystone_url = "${keystone_location}:5000/v3"
+
+  $admin_username = lookup('ntnuopenstack::keystone::admin_username', {
+    'value_type'    => String,
+    'default_value' => 'admin',
+  })
+  $admin_pass = lookup('ntnuopenstack::keystone::admin_password', {
+    'value_type' => String,
+  })
+
+  $externalnets = lookup('ntnuopenstack::neutron::networks::external', {
+    'value_type' => Hash,
+  })
+
+  $externalnets.each | $key, $data | {
+    $net = $data['name']
+    munin::plugin { "openstack_ipuse_${net}":
+      ensure => present,
+      source => 'puppet:///modules/profile/muninplugins/openstack_ipuse_',
+      config => [ 'user neutron',
+        'env.OS_PROJECT_NAME admin',
+        "env.OS_USERNAME ${admin_username}",
+        "env.OS_PASSWORD ${admin_pass}",
+        "env.OS_AUTH_URL ${keystone_url}",
+        'env.OS_IDENTITY_API_VERSION 3',
+      ],
+    }
+  }
+
+  $externalnames = $externalnets.map | $key, $data | { $data['name'] }
+  $externals = join($externalnames, ' ')
+
+  munin::plugin { 'openstack_floatingip':
+    ensure => present,
+    source => 'puppet:///modules/profile/muninplugins/openstack_floatingip',
+    config => [ 'user neutron',
+      'env.OS_PROJECT_NAME admin',
+      "env.OS_USERNAME ${admin_username}",
+      "env.OS_PASSWORD ${admin_pass}",
+      "env.OS_AUTH_URL ${keystone_url}",
+      'env.OS_IDENTITY_API_VERSION 3',
+    ],
+  }
+
+  munin::plugin { 'openstack_ipuse':
+    ensure => present,
+    source => 'puppet:///modules/profile/muninplugins/openstack_ipuse',
+    config => [ 'user neutron',
+      'env.OS_PROJECT_NAME admin',
+      "env.OS_USERNAME ${admin_username}",
+      "env.OS_PASSWORD ${admin_pass}",
+      "env.OS_AUTH_URL ${keystone_url}",
+      'env.OS_IDENTITY_API_VERSION 3',
+      "env.EXTERNALS ${externals}",
+    ],
+  }
+}

--- a/manifests/monitoring/munin/plugin/neutronnet.pp
+++ b/manifests/monitoring/munin/plugin/neutronnet.pp
@@ -1,0 +1,8 @@
+# This class installs munin-plugins for our neutronnet nodes.
+class profile::monitoring::munin::plugin::neutronnet {
+  munin::plugin { 'openstack_neutron_nstypes':
+    ensure => present,
+    source => 'puppet:///modules/profile/muninplugins/openstack_neutron_nstypes',
+    config => [ 'user neutron' ],
+  }
+}

--- a/manifests/monitoring/munin/plugin/nova.pp
+++ b/manifests/monitoring/munin/plugin/nova.pp
@@ -38,9 +38,83 @@ class profile::monitoring::munin::plugin::nova {
   $externalnames = $externalnets.map | $key, $data | { $data['name'] }
   $externals = join($externalnames, ' ')
 
+  munin::plugin { 'openstack_cpu':
+    ensure => present,
+    source => 'puppet:///modules/profile/muninplugins/openstack_cpu',
+    config => [ 'user nova',
+      'env.OS_PROJECT_NAME admin',
+      "env.OS_USERNAME ${admin_username}",
+      "env.OS_PASSWORD ${admin_pass}",
+      "env.OS_AUTH_URL ${keystone_url}",
+      'env.OS_IDENTITY_API_VERSION 3',
+    ],
+  }
+
+  munin::plugin { 'openstack_disk':
+    ensure => present,
+    source => 'puppet:///modules/profile/muninplugins/openstack_disk',
+    config => [ 'user nova',
+      'env.OS_PROJECT_NAME admin',
+      "env.OS_USERNAME ${admin_username}",
+      "env.OS_PASSWORD ${admin_pass}",
+      "env.OS_AUTH_URL ${keystone_url}",
+      'env.OS_IDENTITY_API_VERSION 3',
+    ],
+  }
+
+  munin::plugin { 'openstack_floatingip':
+    ensure => present,
+    source => 'puppet:///modules/profile/muninplugins/openstack_floatingip',
+    config => [ 'user nova',
+      'env.OS_PROJECT_NAME admin',
+      "env.OS_USERNAME ${admin_username}",
+      "env.OS_PASSWORD ${admin_pass}",
+      "env.OS_AUTH_URL ${keystone_url}",
+      'env.OS_IDENTITY_API_VERSION 3',
+    ],
+  }
+
+  munin::plugin { 'openstack_hypervisors':
+    ensure => present,
+    source => 'puppet:///modules/profile/muninplugins/openstack_hypervisors',
+    config => [ 'user nova',
+      'env.OS_PROJECT_NAME admin',
+      "env.OS_USERNAME ${admin_username}",
+      "env.OS_PASSWORD ${admin_pass}",
+      "env.OS_AUTH_URL ${keystone_url}",
+      'env.OS_IDENTITY_API_VERSION 3',
+    ],
+  }
+
   munin::plugin { 'openstack_ipuse':
     ensure => present,
     source => 'puppet:///modules/profile/muninplugins/openstack_ipuse',
+    config => [ 'user nova',
+      'env.OS_PROJECT_NAME admin',
+      "env.OS_USERNAME ${admin_username}",
+      "env.OS_PASSWORD ${admin_pass}",
+      "env.OS_AUTH_URL ${keystone_url}",
+      'env.OS_IDENTITY_API_VERSION 3',
+      "env.EXTERNALS ${externals}",
+    ],
+  }
+
+  munin::plugin { 'openstack_os_images':
+    ensure => present,
+    source => 'puppet:///modules/profile/muninplugins/openstack_os_images',
+    config => [ 'user nova',
+      'env.OS_PROJECT_NAME admin',
+      "env.OS_USERNAME ${admin_username}",
+      "env.OS_PASSWORD ${admin_pass}",
+      "env.OS_AUTH_URL ${keystone_url}",
+      'env.OS_IDENTITY_API_VERSION 3',
+      "env.EXTERNALS ${externals}",
+    ],
+  }
+
+  munin::plugin { 'openstack_os_instances':
+    ensure => present,
+    source => 'puppet:///modules/profile/muninplugins/openstack_os_instances',
     config => [ 'user nova',
       'env.OS_PROJECT_NAME admin',
       "env.OS_USERNAME ${admin_username}",
@@ -66,54 +140,6 @@ class profile::monitoring::munin::plugin::nova {
   munin::plugin { 'openstack_server_status':
     ensure => present,
     source => 'puppet:///modules/profile/muninplugins/openstack_server_status',
-    config => [ 'user nova',
-      'env.OS_PROJECT_NAME admin',
-      "env.OS_USERNAME ${admin_username}",
-      "env.OS_PASSWORD ${admin_pass}",
-      "env.OS_AUTH_URL ${keystone_url}",
-      'env.OS_IDENTITY_API_VERSION 3',
-    ],
-  }
-
-  munin::plugin { 'openstack_floatingip':
-    ensure => present,
-    source => 'puppet:///modules/profile/muninplugins/openstack_floatingip',
-    config => [ 'user nova',
-      'env.OS_PROJECT_NAME admin',
-      "env.OS_USERNAME ${admin_username}",
-      "env.OS_PASSWORD ${admin_pass}",
-      "env.OS_AUTH_URL ${keystone_url}",
-      'env.OS_IDENTITY_API_VERSION 3',
-    ],
-  }
-
-  munin::plugin { 'openstack_cpu':
-    ensure => present,
-    source => 'puppet:///modules/profile/muninplugins/openstack_cpu',
-    config => [ 'user nova',
-      'env.OS_PROJECT_NAME admin',
-      "env.OS_USERNAME ${admin_username}",
-      "env.OS_PASSWORD ${admin_pass}",
-      "env.OS_AUTH_URL ${keystone_url}",
-      'env.OS_IDENTITY_API_VERSION 3',
-    ],
-  }
-
-  munin::plugin { 'openstack_disk':
-    ensure => present,
-    source => 'puppet:///modules/profile/muninplugins/openstack_disk',
-    config => [ 'user nova',
-      'env.OS_PROJECT_NAME admin',
-      "env.OS_USERNAME ${admin_username}",
-      "env.OS_PASSWORD ${admin_pass}",
-      "env.OS_AUTH_URL ${keystone_url}",
-      'env.OS_IDENTITY_API_VERSION 3',
-    ],
-  }
-
-  munin::plugin { 'openstack_hypervisors':
-    ensure => present,
-    source => 'puppet:///modules/profile/muninplugins/openstack_hypervisors',
     config => [ 'user nova',
       'env.OS_PROJECT_NAME admin',
       "env.OS_USERNAME ${admin_username}",

--- a/manifests/monitoring/munin/plugin/nova.pp
+++ b/manifests/monitoring/munin/plugin/nova.pp
@@ -16,28 +16,6 @@ class profile::monitoring::munin::plugin::nova {
     'value_type' => String,
   })
 
-  $externalnets = lookup('ntnuopenstack::neutron::networks::external', {
-    'value_type' => Hash,
-  })
-
-  $externalnets.each | $key, $data | {
-    $net = $data['name']
-    munin::plugin { "openstack_ipuse_${net}":
-      ensure => present,
-      source => 'puppet:///modules/profile/muninplugins/openstack_ipuse_',
-      config => [ 'user nova',
-        'env.OS_PROJECT_NAME admin',
-        "env.OS_USERNAME ${admin_username}",
-        "env.OS_PASSWORD ${admin_pass}",
-        "env.OS_AUTH_URL ${keystone_url}",
-        'env.OS_IDENTITY_API_VERSION 3',
-      ],
-    }
-  }
-
-  $externalnames = $externalnets.map | $key, $data | { $data['name'] }
-  $externals = join($externalnames, ' ')
-
   munin::plugin { 'openstack_cpu':
     ensure => present,
     source => 'puppet:///modules/profile/muninplugins/openstack_cpu',
@@ -62,18 +40,6 @@ class profile::monitoring::munin::plugin::nova {
     ],
   }
 
-  munin::plugin { 'openstack_floatingip':
-    ensure => present,
-    source => 'puppet:///modules/profile/muninplugins/openstack_floatingip',
-    config => [ 'user nova',
-      'env.OS_PROJECT_NAME admin',
-      "env.OS_USERNAME ${admin_username}",
-      "env.OS_PASSWORD ${admin_pass}",
-      "env.OS_AUTH_URL ${keystone_url}",
-      'env.OS_IDENTITY_API_VERSION 3',
-    ],
-  }
-
   munin::plugin { 'openstack_hypervisors':
     ensure => present,
     source => 'puppet:///modules/profile/muninplugins/openstack_hypervisors',
@@ -86,48 +52,9 @@ class profile::monitoring::munin::plugin::nova {
     ],
   }
 
-  munin::plugin { 'openstack_ipuse':
-    ensure => present,
-    source => 'puppet:///modules/profile/muninplugins/openstack_ipuse',
-    config => [ 'user nova',
-      'env.OS_PROJECT_NAME admin',
-      "env.OS_USERNAME ${admin_username}",
-      "env.OS_PASSWORD ${admin_pass}",
-      "env.OS_AUTH_URL ${keystone_url}",
-      'env.OS_IDENTITY_API_VERSION 3',
-      "env.EXTERNALS ${externals}",
-    ],
-  }
-
-  munin::plugin { 'openstack_os_images':
-    ensure => present,
-    source => 'puppet:///modules/profile/muninplugins/openstack_os_images',
-    config => [ 'user nova',
-      'env.OS_PROJECT_NAME admin',
-      "env.OS_USERNAME ${admin_username}",
-      "env.OS_PASSWORD ${admin_pass}",
-      "env.OS_AUTH_URL ${keystone_url}",
-      'env.OS_IDENTITY_API_VERSION 3',
-      "env.EXTERNALS ${externals}",
-    ],
-  }
-
   munin::plugin { 'openstack_os_instances':
     ensure => present,
     source => 'puppet:///modules/profile/muninplugins/openstack_os_instances',
-    config => [ 'user nova',
-      'env.OS_PROJECT_NAME admin',
-      "env.OS_USERNAME ${admin_username}",
-      "env.OS_PASSWORD ${admin_pass}",
-      "env.OS_AUTH_URL ${keystone_url}",
-      'env.OS_IDENTITY_API_VERSION 3',
-      "env.EXTERNALS ${externals}",
-    ],
-  }
-
-  munin::plugin { 'openstack_projects':
-    ensure => present,
-    source => 'puppet:///modules/profile/muninplugins/openstack_projects',
     config => [ 'user nova',
       'env.OS_PROJECT_NAME admin',
       "env.OS_USERNAME ${admin_username}",


### PR DESCRIPTION
This PR pulls in two changes:
 - Add munin-plugins for each openstack-service instead of having then all on novaapi.
 - Ceph-plugins are not anymore dependent on the insights module.

In addition there are some fixes fixing bugs in neutron munin-plugins where external networks are having both IPv4 and IPv6 subnets. 