### PR TITLE
Manage I/O-Scheduler

### DIFF
--- a/files/utilities/get-io-queue.sh
+++ b/files/utilities/get-io-queue.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+cat /sys/block/${1}/queue/nr_requests

--- a/files/utilities/get-io-scheduler.sh
+++ b/files/utilities/get-io-scheduler.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+cat /sys/block/${1}/queue/scheduler | grep -Eo '\[(.*)\]' | grep -E '[a-z]+' -o

--- a/files/utilities/verify-io-queue.sh
+++ b/files/utilities/verify-io-queue.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+[[ $(cat /sys/block/${1}/queue/nr_requests) -eq $2 ]]
+exit $?

--- a/files/utilities/verify-io-scheduler.sh
+++ b/files/utilities/verify-io-scheduler.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+[[ $(cat /sys/block/${1}/queue/scheduler | grep -Eo '\[(.*)\]' | grep -E '[a-z]+' -o) == $2 ]]
+exit $?

--- a/manifests/baseconfig.pp
+++ b/manifests/baseconfig.pp
@@ -2,6 +2,7 @@
 class profile::baseconfig {
   include ::profile::baseconfig::firewall
   include ::profile::baseconfig::git
+  include ::profile::baseconfig::ioscheduler
   include ::profile::baseconfig::mounts
   include ::profile::baseconfig::networking
   include ::profile::baseconfig::ntp

--- a/manifests/baseconfig/ioscheduler.pp
+++ b/manifests/baseconfig/ioscheduler.pp
@@ -17,7 +17,7 @@ class profile::baseconfig::ioscheduler {
   $hdds.each | $hdd | {
     exec { "set ${hdd} to HDD-scheduler":
       command => "echo deadline > /sys/block/${hdd}/queue/scheduler",
-      unless  => "verify-io-scheduler.sh ${ssd} deadline",
+      unless  => "verify-io-scheduler.sh ${hdd} deadline",
       path    => '/usr/local/bin:/bin',
     }
   }

--- a/manifests/baseconfig/ioscheduler.pp
+++ b/manifests/baseconfig/ioscheduler.pp
@@ -4,25 +4,21 @@ class profile::baseconfig::ioscheduler {
   $ssds = lookup('profile::disk::ssds', Array[String], 'unique', [])
   $hdds = lookup('profile::disk::hdds', Array[String], 'unique', [])
 
+  require ::profile::baseconfig::ioscheduler::scripts
+
   $ssds.each | $ssd | {
     exec { "set ${ssd} to SSD-scheduler":
       command => "echo noop > /sys/block/${ssd}/queue/scheduler",
-      unless  => " [[ \
-        $(cat /sys/block/${ssd}/queue/scheduler | \
-        grep -Eo '\[(.*)\]' | grep -E '[a-z]+' -o) \
-        == 'noop' ]]",
-      path    => '/bin',
+      unless  => "verify-io-scheduler.sh ${ssd} noop",
+      path    => '/usr/local/bin:/bin',
     }
   }
 
   $hdds.each | $hdd | {
     exec { "set ${hdd} to HDD-scheduler":
       command => "echo deadline > /sys/block/${hdd}/queue/scheduler",
-      unless  => " [[ \
-        $(cat /sys/block/${hdd}/queue/scheduler | \
-        grep -Eo '\[(.*)\]' | grep -E '[a-z]+' -o) \
-        == 'deadline' ]]",
-      path    => '/bin',
+      unless  => "verify-io-scheduler.sh ${ssd} deadline",
+      path    => '/usr/local/bin:/bin',
     }
   }
 }

--- a/manifests/baseconfig/ioscheduler.pp
+++ b/manifests/baseconfig/ioscheduler.pp
@@ -7,7 +7,7 @@ class profile::baseconfig::ioscheduler {
       Enum['noop', 'deadline', 'cfq'], 'first', 'noop')
 
   $hdds = lookup('profile::disk::hdds', Array[String], 'unique', [])
-  $hddqueue = lookup('profile::disk::ssd::queue', Integer, 'first', 512) 
+  $hddqueue = lookup('profile::disk::hdd::queue', Integer, 'first', 512) 
   $hddscheduler = lookup('profile::disk::hdd::scheduler', 
       Enum['noop', 'deadline', 'cfq'], 'first', 'cfq')
 

--- a/manifests/baseconfig/ioscheduler.pp
+++ b/manifests/baseconfig/ioscheduler.pp
@@ -11,9 +11,9 @@ class profile::baseconfig::ioscheduler {
   $hddscheduler = lookup('profile::disk::hdd::scheduler', 
       Enum['noop', 'deadline', 'cfq'], 'first', 'cfq')
 
-  require ::profile::baseconfig::ioscheduler::scripts
-
   $ssds.each | $ssd | {
+    require ::profile::baseconfig::ioscheduler::scripts
+
     exec { "set ${ssd} to io-scheduler ${ssdscheduler}":
       command => "echo ${ssdscheduler} > /sys/block/${ssd}/queue/scheduler",
       unless  => "verify-io-scheduler.sh ${ssd} ${ssdscheduler}",
@@ -27,6 +27,8 @@ class profile::baseconfig::ioscheduler {
   }
 
   $hdds.each | $hdd | {
+    require ::profile::baseconfig::ioscheduler::scripts
+
     exec { "set ${hdd} to io-scheduler ${hddscheduler}":
       command => "echo ${hddscheduler} > /sys/block/${hdd}/queue/scheduler",
       unless  => "verify-io-scheduler.sh ${hdd} ${hddscheduler}",

--- a/manifests/baseconfig/ioscheduler.pp
+++ b/manifests/baseconfig/ioscheduler.pp
@@ -1,0 +1,28 @@
+# This class switches to a simpler io-scheduler for disks listed in hiera. The
+# purpose is to make scheduling to SSD's more efficient. 
+class profile::baseconfig::ioscheduler {
+  $ssds = lookup('profile::disk::ssds', Array[String], 'unique', [])
+  $hdds = lookup('profile::disk::hdds', Array[String], 'unique', [])
+
+  $ssds.each | $ssd | {
+    exec { "set ${ssd} to SSD-scheduler":
+      command => "echo noop > /sys/block/${ssd}/queue/scheduler",
+      unless  => " [[ \
+        $(cat /sys/block/${ssd}/queue/scheduler | \
+        grep -Eo '\[(.*)\]' | grep -E '[a-z]+' -o) \
+        == 'noop' ]]",
+      path    => '/bin',
+    }
+  }
+
+  $hdds.each | $hdd | {
+    exec { "set ${hdd} to HDD-scheduler":
+      command => "echo deadline > /sys/block/${hdd}/queue/scheduler",
+      unless  => " [[ \
+        $(cat /sys/block/${hdd}/queue/scheduler | \
+        grep -Eo '\[(.*)\]' | grep -E '[a-z]+' -o) \
+        == 'deadline' ]]",
+      path    => '/bin',
+    }
+  }
+}

--- a/manifests/baseconfig/ioscheduler.pp
+++ b/manifests/baseconfig/ioscheduler.pp
@@ -2,22 +2,26 @@
 # purpose is to make scheduling to SSD's more efficient. 
 class profile::baseconfig::ioscheduler {
   $ssds = lookup('profile::disk::ssds', Array[String], 'unique', [])
+  $ssdscheduler = lookup('profile::disk::ssd::scheduler', 
+      Enum['noop', 'deadline', 'cfq'], 'first', 'noop')
   $hdds = lookup('profile::disk::hdds', Array[String], 'unique', [])
+  $hddscheduler = lookup('profile::disk::hdd::scheduler', 
+      Enum['noop', 'deadline', 'cfq'], 'first', 'cfq')
 
   require ::profile::baseconfig::ioscheduler::scripts
 
   $ssds.each | $ssd | {
     exec { "set ${ssd} to SSD-scheduler":
-      command => "echo noop > /sys/block/${ssd}/queue/scheduler",
-      unless  => "verify-io-scheduler.sh ${ssd} noop",
+      command => "echo ${ssdscheduler} > /sys/block/${ssd}/queue/scheduler",
+      unless  => "verify-io-scheduler.sh ${ssd} ${ssdscheduler}",
       path    => '/usr/local/bin:/bin',
     }
   }
 
   $hdds.each | $hdd | {
     exec { "set ${hdd} to HDD-scheduler":
-      command => "echo deadline > /sys/block/${hdd}/queue/scheduler",
-      unless  => "verify-io-scheduler.sh ${hdd} deadline",
+      command => "echo ${hddscheduler} > /sys/block/${hdd}/queue/scheduler",
+      unless  => "verify-io-scheduler.sh ${hdd} ${hddscheduler}",
       path    => '/usr/local/bin:/bin',
     }
   }

--- a/manifests/baseconfig/ioscheduler.pp
+++ b/manifests/baseconfig/ioscheduler.pp
@@ -2,26 +2,39 @@
 # purpose is to make scheduling to SSD's more efficient. 
 class profile::baseconfig::ioscheduler {
   $ssds = lookup('profile::disk::ssds', Array[String], 'unique', [])
+  $ssdqueue = lookup('profile::disk::ssd::queue', Integer, 'first', 4096) 
   $ssdscheduler = lookup('profile::disk::ssd::scheduler', 
       Enum['noop', 'deadline', 'cfq'], 'first', 'noop')
+
   $hdds = lookup('profile::disk::hdds', Array[String], 'unique', [])
+  $hddqueue = lookup('profile::disk::ssd::queue', Integer, 'first', 512) 
   $hddscheduler = lookup('profile::disk::hdd::scheduler', 
       Enum['noop', 'deadline', 'cfq'], 'first', 'cfq')
 
   require ::profile::baseconfig::ioscheduler::scripts
 
   $ssds.each | $ssd | {
-    exec { "set ${ssd} to SSD-scheduler":
+    exec { "set ${ssd} to io-scheduler ${ssdscheduler}":
       command => "echo ${ssdscheduler} > /sys/block/${ssd}/queue/scheduler",
       unless  => "verify-io-scheduler.sh ${ssd} ${ssdscheduler}",
+      path    => '/usr/local/bin:/bin',
+    }
+    exec { "set ${ssd} quelength to ${ssdqueue}":
+      command => "echo ${ssdqueue} > /sys/block/${ssd}/queue/nr_requests",
+      unless  => "verify-io-queue.sh ${ssd} ${ssdqueue}",
       path    => '/usr/local/bin:/bin',
     }
   }
 
   $hdds.each | $hdd | {
-    exec { "set ${hdd} to HDD-scheduler":
+    exec { "set ${hdd} to io-scheduler ${hddscheduler}":
       command => "echo ${hddscheduler} > /sys/block/${hdd}/queue/scheduler",
       unless  => "verify-io-scheduler.sh ${hdd} ${hddscheduler}",
+      path    => '/usr/local/bin:/bin',
+    }
+    exec { "set ${hdd} quelength to ${hddqueue}":
+      command => "echo ${hddqueue} > /sys/block/${hdd}/queue/nr_requests",
+      unless  => "verify-io-queue.sh ${hdd} ${hddqueue}",
       path    => '/usr/local/bin:/bin',
     }
   }

--- a/manifests/baseconfig/ioscheduler/scripts.pp
+++ b/manifests/baseconfig/ioscheduler/scripts.pp
@@ -1,0 +1,15 @@
+# Installs utility-scripts for ioscheduler-tuning
+class profile::baseconfig::ioscheduler::scripts {
+  $scripts = [
+    'get-io-queue.sh', 'verify-io-queue.sh',
+    'get-io-scheduler.sh', 'verify-io-scheduler.sh',
+  ]
+
+  $scripts.each | $script | {
+    file { '/usr/local/bin/${script}':
+      ensure => file,
+      source => 'puppet:///modules/profile/utilities/${script}',
+      mode   => '0555',
+    }
+  }
+}

--- a/manifests/baseconfig/ioscheduler/scripts.pp
+++ b/manifests/baseconfig/ioscheduler/scripts.pp
@@ -6,7 +6,7 @@ class profile::baseconfig::ioscheduler::scripts {
   ]
 
   $scripts.each | $script | {
-    file { '/usr/local/bin/${script}':
+    file { "/usr/local/bin/${script}":
       ensure => file,
       source => 'puppet:///modules/profile/utilities/${script}',
       mode   => '0555',

--- a/manifests/baseconfig/ioscheduler/scripts.pp
+++ b/manifests/baseconfig/ioscheduler/scripts.pp
@@ -8,7 +8,7 @@ class profile::baseconfig::ioscheduler::scripts {
   $scripts.each | $script | {
     file { "/usr/local/bin/${script}":
       ensure => file,
-      source => 'puppet:///modules/profile/utilities/${script}',
+      source => "puppet:///modules/profile/utilities/${script}",
       mode   => '0555',
     }
   }


### PR DESCRIPTION
Adding scripts to manage the io-scheduler. Requires a disk to be listed in hiera to be managed. The disks should be listed as strings under the hiera-keys:

- `profile::disk::ssds`
- `profile::disk::hdds`

The script also modifies the request-queue-length (512 and 4096 requests for hdds and ssds) to allow more requests in-flight. This improves performance.

The selected I/O-scheduler and the queue-length can both be modified through hiera if needed.