### PR TITLE
Logrotation and Munin-plugins for IP-use

### DIFF
--- a/files/muninplugins/openstack_ipuse
+++ b/files/muninplugins/openstack_ipuse
@@ -8,21 +8,24 @@ if [[ $1 == "config" ]]; then
   echo "graph_scale no"
   echo "graph_info Amount of IPs in use from external networks"
   for net in $EXTERNALS; do
-    echo ${net/\-/}.label $net
-    echo ${net/\-/}.info IPs utilized from $net
+    echo "${net/\-/}.label $net"
+    echo "${net/\-/}.info IPs utilized from $net"
   done
   exit 0
 fi
 
 for net in $EXTERNALS; do
-  value=$(openstack ip availability show $net -f value -c subnet_ip_availability | grep "ip_version='4'")
-
-  [[ $value =~ total_ips=\'([0-9]+)\' ]]
-  total=${BASH_REMATCH[1]}
-
-  [[ $value =~ used_ips=\'([0-9]+)\' ]]
-  used=${BASH_REMATCH[1]}
+  used=0
+  total=0
+  
+  for subnet in $(openstack ip availability show "$net" -f value -c subnet_ip_availability | tr "'" '"' | jq '.[]' -c); do
+      version=$(echo "$subnet" | jq '.["ip_version"]')
+      if [[ $version -eq 4 ]]; then
+        ((total+=$(echo "$subnet" | jq '.["total_ips"]')))
+        ((used+=$(echo "$subnet" | jq '.["used_ips"]')))
+      fi
+  done
 
   value=$(echo "scale=2;${used}*100/${total}" | bc)
-  echo ${net/\-/}.value $value
+  echo "${net/\-/}.value $value"
 done

--- a/files/muninplugins/openstack_ipuse_
+++ b/files/muninplugins/openstack_ipuse_
@@ -12,9 +12,9 @@ if [[ $1 == "config" ]]; then
   echo "graph_info Amount of allocated and used IP's for the network $net"
   echo "total.label Available"
   echo "total.info Number of available IPv4 addresses"
-  echo "used.label Used"
+  echo "used.label Used IPv4"
   echo "used.info Number of used IPv4 addresses"
-  echo "used6.label Used"
+  echo "used6.label Used IPv6"
   echo "used6.info Number of used IPv6 addresses"
   exit 0
 fi

--- a/files/muninplugins/openstack_ipuse_
+++ b/files/muninplugins/openstack_ipuse_
@@ -11,15 +11,28 @@ if [[ $1 == "config" ]]; then
   echo "graph_scale yes"
   echo "graph_info Amount of allocated and used IP's for the network $net"
   echo "total.label Available"
-  echo "total.info Number of available IP's"
+  echo "total.info Number of available IPv4 addresses"
   echo "used.label Used"
-  echo "used.info Number of used IP's"
+  echo "used.info Number of used IPv4 addresses"
+  echo "used6.label Used"
+  echo "used6.info Number of used IPv6 addresses"
   exit 0
 fi
 
-value=$(openstack ip availability show $net -f value -c subnet_ip_availability | grep "ip_version='4'")
-[[ $value =~ total_ips=\'([0-9]+)\' ]]
-echo "total.value ${BASH_REMATCH[1]}"
+used4=0
+used6=0
+total=0
 
-[[ $value =~ used_ips=\'([0-9]+)\' ]]
-echo "used.value ${BASH_REMATCH[1]}"
+for subnet in $(openstack ip availability show ntnu-global -f value -c subnet_ip_availability | tr "'" '"' | jq '.[]' -c); do
+    version=$(echo "$subnet" | jq '.["ip_version"]')
+    if [[ $version -eq 4 ]]; then
+      ((total+=$(echo "$subnet" | jq '.["total_ips"]')))
+      ((used4+=$(echo "$subnet" | jq '.["used_ips"]')))
+    elif [[ $version -eq 6 ]]; then
+      ((used6+=$(echo "$subnet" | jq '.["used_ips"]')))
+    fi
+done
+
+echo "used.value $used4" 
+echo "used6.value $used6" 
+echo "total.value $total" 

--- a/manifests/monitoring/munin/server/vhost.pp
+++ b/manifests/monitoring/munin/server/vhost.pp
@@ -20,7 +20,7 @@ define profile::monitoring::munin::server::vhost {
     $ip = [$management_ipv4]
   }
 
-  apache::vhost { "${name} http":
+  apache::vhost { "${name}-http":
     servername        => $name,
     serveraliases     => [$name],
     port              => '80',

--- a/manifests/sensu/uchiwa.pp
+++ b/manifests/sensu/uchiwa.pp
@@ -52,7 +52,7 @@ class profile::sensu::uchiwa {
   include ::apache::mod::proxy
   include ::apache::mod::proxy_html
 
-  apache::vhost { "${uchiwa_url} http":
+  apache::vhost { "${uchiwa_url}-http":
     servername          => $uchiwa_url,
     serveraliases       => [$uchiwa_url],
     port                => 80,

--- a/manifests/services/apache.pp
+++ b/manifests/services/apache.pp
@@ -39,7 +39,7 @@ class profile::services::apache {
     apache::listen { "[${management_ipv6}]:80": }
   }
 
-  apache::vhost { "${::fqdn} http":
+  apache::vhost { "${::fqdn}-http":
     servername    => $::fqdn,
     port          => '80',
     ip            => $ip,

--- a/manifests/services/dashboard/apache.pp
+++ b/manifests/services/dashboard/apache.pp
@@ -34,7 +34,7 @@ class profile::services::dashboard::apache {
   </Files>
 </Directory>'
 
-  apache::vhost { "${dashboardname} http":
+  apache::vhost { "${dashboardname}-http":
     servername          => $dashboardname,
     port                => '80',
     ip                  => concat([], $management_ipv4, $management_ipv6),
@@ -56,7 +56,7 @@ class profile::services::dashboard::apache {
   }
 
   if($dashboardv4name) {
-    apache::vhost { "${dashboardv4name} http":
+    apache::vhost { "${dashboardv4name}-http":
       servername          => $dashboardv4name,
       port                => '80',
       ip                  => concat([], $management_ipv4, $management_ipv6),

--- a/manifests/services/info.pp
+++ b/manifests/services/info.pp
@@ -15,7 +15,7 @@ class profile::services::info {
   require ::profile::services::apache
   contain ::profile::services::info::maillist
 
-  apache::vhost { "${vhost} http":
+  apache::vhost { "${vhost}-http":
     servername        => $vhost,
     port              => '80',
     ip                => concat([], $management_ipv4, $management_ipv6),


### PR DESCRIPTION
This PR fixes some broken logrotation for some of our apache vhosts and updates the munin-plugins for ip-use to work with multiple subnets, and the format returned by openstack train.