### PR TITLE
Adjustments needed for CentOS 8

### DIFF
--- a/example/hieradata/CentOS/networking.yaml
+++ b/example/hieradata/CentOS/networking.yaml
@@ -1,0 +1,2 @@
+---
+network::service_restart_exec: 'systemctl restart network.service'

--- a/example/hieradata/CentOS/sensu.yaml
+++ b/example/hieradata/CentOS/sensu.yaml
@@ -1,0 +1,3 @@
+---
+sensu::version: '1.9.0-1.el7'
+sensu::manage_repo: false

--- a/manifests/baseconfig/network/ifupdown.pp
+++ b/manifests/baseconfig/network/ifupdown.pp
@@ -78,7 +78,7 @@ class profile::baseconfig::network::ifupdown (Hash $nics) {
     }
 
     $table_id = $params['tableid']
-    if($table_id and $nic in $::facts['networking']['interface']) {
+    if($table_id and $nic in $::facts['networking']['interfaces']) {
       if($::facts['networking']['interfaces'][$nic]['ip']) {
         $net4id = $::facts['networking']['interfaces'][$nic]['network']
         $net4mask = $::facts['networking']['interfaces'][$nic]['netmask']

--- a/manifests/baseconfig/ntp.pp
+++ b/manifests/baseconfig/ntp.pp
@@ -1,5 +1,6 @@
 # This class installs and configures NTP.
 class profile::baseconfig::ntp {
+  $installsensu = lookup('profile::sensu::install')
   $ntpservers = lookup('profile::ntp::servers')
   $tz = lookup('profile::ntp::timezone', {
     'value_type'    => String,
@@ -11,6 +12,9 @@ class profile::baseconfig::ntp {
       class { '::chrony':
         servers => $ntpservers
       }
+      if($installsensu) {
+        sensu::subscription { 'chrony': }
+      }
     }
     'Ubuntu': {
       class { '::ntp':
@@ -21,6 +25,9 @@ class profile::baseconfig::ntp {
           'default kod nomodify notrap nopeer noquery',
           '-6 default kod nomodify notrap nopeer noquery',
         ],
+      }
+      if($installsensu) {
+        sensu::subscription { 'ntpd': }
       }
     }
     default: {

--- a/manifests/baseconfig/ntp.pp
+++ b/manifests/baseconfig/ntp.pp
@@ -1,20 +1,34 @@
 # This class installs and configures NTP.
 class profile::baseconfig::ntp {
-  $ntpServers = hiera('profile::ntp::servers')
-  $tz = hiera('profile::ntp::timezone', 'Europe/Oslo')
+  $ntpservers = lookup('profile::ntp::servers')
+  $tz = lookup('profile::ntp::timezone', {
+    'value_type'    => String,
+    'default_value' => 'Europe/Oslo'
+  })
 
-  class { '::ntp':
-    servers  => $ntpServers,
-    restrict => [
-      '127.0.0.1',
-      '-6 ::1',
-      'default kod nomodify notrap nopeer noquery',
-      '-6 default kod nomodify notrap nopeer noquery',
-    ],
+  case $::operatingsystem {
+    'CentOS': {
+      class { '::chrony':
+        servers => $ntpservers
+      }
+    }
+    'Ubuntu': {
+      class { '::ntp':
+        servers  => $ntpservers,
+        restrict => [
+          '127.0.0.1',
+          '-6 ::1',
+          'default kod nomodify notrap nopeer noquery',
+          '-6 default kod nomodify notrap nopeer noquery',
+        ],
+      }
+    }
+    default: {
+      fail("Unsopperted operating system: ${::operatingsystem}")
+    }
   }
 
-  file {'/etc/localtime':
-    ensure => link,
-    target => "/usr/share/zoneinfo/${tz}"
+  class { '::timezone':
+    timezone => $tz,
   }
 }

--- a/manifests/infrastructure/ovs/port/bond.pp
+++ b/manifests/infrastructure/ovs/port/bond.pp
@@ -68,13 +68,14 @@ define profile::infrastructure::ovs::port::bond (
       # CentOS
       $mac = $::facts['networking']['interfaces'][$ifname]['mac']
       ::network::interface { $ifname:
-        interface  => $ifname,
-        hwaddr     => $mac,
-        type       => 'OVSPort',
-        devicetype => 'ovs',
-        ovs_bridge => $bridge,
-        onboot     => 'yes',
-        mtu        => $mtu,
+        interface     => $ifname,
+        hwaddr        => $mac,
+        type          => 'OVSPort',
+        devicetype    => 'ovs',
+        ovs_bridge    => $bridge,
+        onboot        => 'yes',
+        mtu           => $mtu,
+        nm_controlled => 'no',
       }
     }
 

--- a/manifests/monitoring/munin/deps.pp
+++ b/manifests/monitoring/munin/deps.pp
@@ -1,0 +1,10 @@
+# Dependencies
+class profile::monitoring::munin::deps {
+  if $facts['os']['family'] {
+    if $facts['os']['release']['major'] == '8' {
+      yumrepo { 'PowerTools':
+        enabled => '1',
+      }
+    }
+  }
+}

--- a/manifests/monitoring/munin/node.pp
+++ b/manifests/monitoring/munin/node.pp
@@ -1,5 +1,6 @@
 # Defines a generic munin node
 class profile::monitoring::munin::node {
+  require ::profile::monitoring::munin::deps
   include ::profile::monitoring::munin::node::firewall
   include ::profile::monitoring::munin::plugin::general
   include ::profile::monitoring::munin::plugin::puppet

--- a/manifests/sensu/checks/base.pp
+++ b/manifests/sensu/checks/base.pp
@@ -47,10 +47,16 @@ class profile::sensu::checks::base {
     subscribers => [ 'all' ],
   }
 
-  sensu::check { 'ntp-offset':
+  sensu::check { 'ntp-offset-ntpd':
     command     => 'check-ntp.rb -w :::ntp.warn|10::: -c :::ntp.crit|100:::',
     interval    => 300,
     standalone  => false,
-    subscribers => [ 'all' ],
+    subscribers => [ 'ntpd' ],
+  }
+  sensu::check { 'ntp-offset-chrony':
+    command     => 'check-chrony.rb --warn-offset :::ntp.warn|10::: --crit-offset :::ntp.crit|100:::',
+    interval    => 300,
+    standalone  => false,
+    subscribers => [ 'chrony' ],
   }
 }

--- a/manifests/utilities/machinetools.pp
+++ b/manifests/utilities/machinetools.pp
@@ -27,10 +27,8 @@ class profile::utilities::machinetools {
         }
       }
       'RedHat': {
-        package { 'mpt-status':
+        package { 'ncurses-compat-libs':
           ensure   => 'present',
-          provider => 'rpm',
-          source   => 'http://rpm.iik.ntnu.no/mpt-status-1.2.0-4.el7.centos.x86_64.rpm',
         }
         package { 'MegaCli':
           ensure   => 'present',

--- a/manifests/utilities/machinetools.pp
+++ b/manifests/utilities/machinetools.pp
@@ -14,7 +14,7 @@ class profile::utilities::machinetools {
   if($::bios_vendor == 'Dell Inc.' and $machinetools) {
     include ::srvadmin
 
-    case $osfamily {
+    case $::osfamily {
       'Debian': {
         include ::hwraid
         $megaclipackages = [ 'megacli', 'mpt-status' ]


### PR DESCRIPTION
Small changes needed for CentOS 8 compatibility.

Needs some hierakeys in the CentOS-specific folder:
Sensu is not available for CentOS 8, but we ninja install the CentOS 7 rpm when a server is deployed. Set this:
  - sensu::version: '1.9.0-1.el7'
  - sensu::manage_repo: false

If you deploy CentOS 8 without NetworkManager, set this:
  - network::service_restart_exec: 'systemctl restart network.service'