### PR TITLE
Munin snmp

### DIFF
--- a/manifests/monitoring/munin/plugin/snmp.pp
+++ b/manifests/monitoring/munin/plugin/snmp.pp
@@ -22,16 +22,20 @@ class profile::monitoring::munin::plugin::snmp {
       }
     }
 
-    $data['interfaces'].each | $id, $data | {
+    $data['interfaces'].each | $id, $ifdata | {
       munin::plugin { "snmp_${host}_if_${id}":
         ensure => link,
         target => '/usr/share/munin/plugins/snmp__if_',
         config => ["env.community ${community}"],
       }
-      munin::plugin { "snmp_${host}_if_err_${id}":
-        ensure => link,
-        target => '/usr/share/munin/plugins/snmp__if_err_',
-        config => ["env.community ${community}"],
+
+      $errors = pick($ifdata['errors'], false)
+      if($errors) {
+        munin::plugin { "snmp_${host}_if_err_${id}":
+          ensure => link,
+          target => '/usr/share/munin/plugins/snmp__if_err_',
+          config => ["env.community ${community}"],
+        }
       }
     }
   }

--- a/manifests/monitoring/munin/plugin/snmp.pp
+++ b/manifests/monitoring/munin/plugin/snmp.pp
@@ -1,0 +1,38 @@
+# This class sets up the needed munin-plugins to monitor a switch/router over
+# SNMP.
+class profile::monitoring::munin::plugin::snmp {
+  $devices = lookup('profile::snmp::devices', {
+    'value_type'    => Hash,
+    'default_value' => {},
+  })
+
+  $devices.each | $host, $data | {
+    munin::master::node_definition { $host:
+      address => '127.0.0.1',
+      config  => ['use_node_name no'],
+    }
+
+    $community = $data['community']
+
+    $data['plugins'].each | $plugin | {
+      munin::plugin { "snmp_${host}_${plugin}":
+        ensure => link,
+        target => "/usr/share/munin/plugins/snmp__${plugin}",
+        config => ["env.community ${community}"],
+      }
+    }
+
+    $data['interfaces'].each | $id, $data | {
+      munin::plugin { "snmp_${host}_if_${id}":
+        ensure => link,
+        target => '/usr/share/munin/plugins/snmp__if_',
+        config => ["env.community ${community}"],
+      }
+      munin::plugin { "snmp_${host}_if_err_${id}":
+        ensure => link,
+        target => '/usr/share/munin/plugins/snmp__if_err_',
+        config => ["env.community ${community}"],
+      }
+    }
+  }
+}

--- a/manifests/monitoring/munin/server.pp
+++ b/manifests/monitoring/munin/server.pp
@@ -4,6 +4,7 @@ class profile::monitoring::munin::server {
   $munin_urls = hiera('profile::munin::urls')
 
   contain ::profile::monitoring::munin::haproxy::balancermember
+  include ::profile::monitoring::munin::plugin::snmp
 
   class{ '::munin::master':
     extra_config => [


### PR DESCRIPTION
Add munin-plugins to monitor switches over SNMP. Munin-master-servers will query switches based on the following hierakey:

```
profile::snmp::devices:
  'router.host.name.tld':
     community: 'supersecretcommunitystring'
     interfaces:
       1:
         errors: true
       2:
         errors: true
       5: {}
       6: {}
     plugins:
       - 'uptime'
```

The following config would graph traffic for interface 1,2,5 and 6 of router.host.name.tld, in addition to graphing error-rates for if 1 and 2, and graph of uptime.