### PR TITLE
Externalbackup

### DIFF
--- a/files/utilities/external-sql-backup.sh
+++ b/files/utilities/external-sql-backup.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# This backup script works for both MySQL and PostgreSQL backups
+# in the NTNU Openstack Clouds. Typically invoked via cron
+
+# In a cluster, only one host needs to run this.
+
+# Make sure you have an entry in fstab for the NFS share
+# you intend to backup to.
+
+# We typically do this with a mount resource in puppet
+
+set -e
+
+SOURCE='/var/backups/'
+DEST='/mnt/backup'
+
+if grep -q "$DEST" /etc/fstab ; then
+  mount $DEST
+  rsync -rv --delete --ignore-existing \
+           --include="*/" \
+           --include="*sql.gz" \
+           --exclude="*" ${SOURCE} ${DEST}/$(hostname)
+  umount $DEST
+fi

--- a/manifests/services/backup/sql.pp
+++ b/manifests/services/backup/sql.pp
@@ -1,0 +1,10 @@
+# Install script for MySQL/PostgreSQL external backup
+class profile::services::backup::sql {
+  file { '/usr/local/bin/external-sql-backup.sh':
+    ensure => present,
+    owner  => 'root',
+    group  => 'root',
+    mode   => '0755',
+    source => 'puppet:///modules/profile/utilities/external-sql-backup.sh'
+  }
+}

--- a/manifests/services/mysql/backup.pp
+++ b/manifests/services/mysql/backup.pp
@@ -1,5 +1,11 @@
 # Backups the database content of mysql
 class profile::services::mysql::backup {
+
+  $externa_backup = lookup('profile::mysql::backup::external', {
+    'default_value' => false,
+    'value_type'    => Boolean
+  })
+
   file { '/usr/local/sbin/mysqlbackup.sh':
     ensure => present,
     owner  => 'root',
@@ -28,5 +34,9 @@ class profile::services::mysql::backup {
     user    => 'root',
     hour    => '1',
     minute  => '57',
+  }
+
+  if ($external_backup) {
+    include ::profile::services::mysql::backup::external
   }
 }

--- a/manifests/services/mysql/backup.pp
+++ b/manifests/services/mysql/backup.pp
@@ -1,7 +1,7 @@
 # Backups the database content of mysql
 class profile::services::mysql::backup {
 
-  $externa_backup = lookup('profile::mysql::backup::external', {
+  $external_backup = lookup('profile::mysql::backup::external', {
     'default_value' => false,
     'value_type'    => Boolean
   })

--- a/manifests/services/mysql/backup/external.pp
+++ b/manifests/services/mysql/backup/external.pp
@@ -1,0 +1,12 @@
+# Enable MySQL backup to a external host
+class profile::services::mysql::backup::external {
+
+  require ::profile::services::backup::sql
+
+  cron { 'MySQL external backup':
+    command => '/usr/local/bin/external-sql-backup.sh',
+    user    => 'root',
+    hour    => '2',
+    minute  => '00',
+  }
+}

--- a/manifests/services/postgresql/backup.pp
+++ b/manifests/services/postgresql/backup.pp
@@ -2,6 +2,10 @@
 class profile::services::postgresql::backup {
   $management_if = hiera('profile::interfaces::management')
   $pgip = $facts['networking']['interfaces'][$management_if]['ip']
+  $external_backup = lookup('profile::mysql::backup::external', {
+    'default_value' => false,
+    'value_type'    => Boolean
+  })
 
   file { '/usr/local/sbin/postgresbackup.sh':
     ensure => present,
@@ -31,5 +35,9 @@ class profile::services::postgresql::backup {
     user    => 'root',
     hour    => '1',
     minute  => '14',
+  }
+
+  if ($external_backup) {
+    include ::profile::services::postgresql::backup::external
   }
 }

--- a/manifests/services/postgresql/backup.pp
+++ b/manifests/services/postgresql/backup.pp
@@ -2,7 +2,7 @@
 class profile::services::postgresql::backup {
   $management_if = hiera('profile::interfaces::management')
   $pgip = $facts['networking']['interfaces'][$management_if]['ip']
-  $external_backup = lookup('profile::mysql::backup::external', {
+  $external_backup = lookup('profile::postgresql::backup::external', {
     'default_value' => false,
     'value_type'    => Boolean
   })

--- a/manifests/services/postgresql/backup/external.pp
+++ b/manifests/services/postgresql/backup/external.pp
@@ -1,0 +1,12 @@
+# Enable PostgreSQL backup to a external host
+class profile::services::postgresql::backup::external {
+
+  require ::profile::services::backup::sql
+
+  cron { 'PostgreSQL external backup':
+    command => '/usr/local/bin/external-sql-backup.sh',
+    user    => 'root',
+    hour    => '2',
+    minute  => '30',
+  }
+}


### PR DESCRIPTION
Install a sort-of-generic script for rsyncing SQL-related backups to an external location. In our case, this should be added to mysql and postgresql servers