### PR TITLE
Logrotate

### DIFF
--- a/manifests/baseconfig.pp
+++ b/manifests/baseconfig.pp
@@ -3,6 +3,7 @@ class profile::baseconfig {
   include ::profile::baseconfig::firewall
   include ::profile::baseconfig::git
   include ::profile::baseconfig::ioscheduler
+  include ::profile::baseconfig::logrotate
   include ::profile::baseconfig::mounts
   include ::profile::baseconfig::networking
   include ::profile::baseconfig::ntp

--- a/manifests/baseconfig/logrotate.pp
+++ b/manifests/baseconfig/logrotate.pp
@@ -1,6 +1,15 @@
 # Class to set defaults for logrotate
 class profile::baseconfig::logrotate {
-  logrotate::conf { '/etc/logrotate.conf':
-    compress => true,
+  #logrotate::conf { '/etc/logrotate.conf':
+  #  compress => true,
+  #}
+
+  class { '::logrotate':
+    create_base_rules  => false,
+    manage_cron_daily  => false,
+    manage_cron_hourly => false,
+    config             => {
+      compress => true,
+    }
   }
 }

--- a/manifests/baseconfig/logrotate.pp
+++ b/manifests/baseconfig/logrotate.pp
@@ -1,0 +1,6 @@
+# Class to set defaults for logrotate
+class profile::baseconfig::logrotate {
+  logrotate::conf { '/etc/logrotate.conf':
+    compress => true,
+  }
+}

--- a/manifests/baseconfig/logrotate.pp
+++ b/manifests/baseconfig/logrotate.pp
@@ -1,11 +1,6 @@
 # Class to set defaults for logrotate
 class profile::baseconfig::logrotate {
-  #logrotate::conf { '/etc/logrotate.conf':
-  #  compress => true,
-  #}
-
   class { '::logrotate':
-    create_base_rules  => false,
     config             => {
       compress => true,
     }

--- a/manifests/baseconfig/logrotate.pp
+++ b/manifests/baseconfig/logrotate.pp
@@ -6,8 +6,6 @@ class profile::baseconfig::logrotate {
 
   class { '::logrotate':
     create_base_rules  => false,
-    manage_cron_daily  => false,
-    manage_cron_hourly => false,
     config             => {
       compress => true,
     }


### PR DESCRIPTION
Include a class in baseconfig which configures logrotate to do logfile compression as default. Different services can still override this via its own packages.