### PR TITLE
Munintuning

### DIFF
--- a/manifests/monitoring/munin/rrdcache.pp
+++ b/manifests/monitoring/munin/rrdcache.pp
@@ -1,7 +1,8 @@
 # Install the RRD Cache Daemon and perl bindings
 class profile::monitoring::munin::rrdcache {
   class { 'rrd::cache':
-    gid => 'munin',
+    uid => 'munin',
+    gid => 'www-data',
   }
   include rrd::bindings::perl
 }

--- a/manifests/monitoring/munin/rrdcache.pp
+++ b/manifests/monitoring/munin/rrdcache.pp
@@ -1,8 +1,9 @@
 # Install the RRD Cache Daemon and perl bindings
 class profile::monitoring::munin::rrdcache {
   class { 'rrd::cache':
-    uid => 'munin',
-    gid => 'www-data',
+    uid         => 'munin',
+    gid         => 'www-data',
+    socket_mode => '755',
   }
   include rrd::bindings::perl
 }

--- a/manifests/monitoring/munin/rrdcache.pp
+++ b/manifests/monitoring/munin/rrdcache.pp
@@ -3,7 +3,7 @@ class profile::monitoring::munin::rrdcache {
   class { 'rrd::cache':
     uid         => 'munin',
     gid         => 'www-data',
-    socket_mode => '755',
+    socket_mode => '744',
   }
   include rrd::bindings::perl
 }

--- a/manifests/monitoring/munin/rrdcache.pp
+++ b/manifests/monitoring/munin/rrdcache.pp
@@ -3,7 +3,7 @@ class profile::monitoring::munin::rrdcache {
   class { 'rrd::cache':
     uid         => 'munin',
     gid         => 'www-data',
-    socket_mode => '744',
+    socket_mode => '766',
   }
   include rrd::bindings::perl
 }

--- a/manifests/monitoring/munin/rrdcache.pp
+++ b/manifests/monitoring/munin/rrdcache.pp
@@ -1,0 +1,5 @@
+# Install the RRD Cache Daemon and perl bindings
+class profile::monitoring::munin::rrdcache {
+  include rrd::cache
+  include rrd::bindings::perl
+}

--- a/manifests/monitoring/munin/rrdcache.pp
+++ b/manifests/monitoring/munin/rrdcache.pp
@@ -1,7 +1,7 @@
 # Install the RRD Cache Daemon and perl bindings
 class profile::monitoring::munin::rrdcache {
   class { 'rrd::cache':
-    gid => 'www-data',
+    gid => 'munin',
   }
   include rrd::bindings::perl
 }

--- a/manifests/monitoring/munin/rrdcache.pp
+++ b/manifests/monitoring/munin/rrdcache.pp
@@ -1,5 +1,7 @@
 # Install the RRD Cache Daemon and perl bindings
 class profile::monitoring::munin::rrdcache {
-  include rrd::cache
+  class { 'rrd::cache':
+    gid => 'www-data',
+  }
   include rrd::bindings::perl
 }

--- a/manifests/monitoring/munin/server.pp
+++ b/manifests/monitoring/munin/server.pp
@@ -9,7 +9,7 @@ class profile::monitoring::munin::server {
     'value_type'    => Integer,
   })
 
-  require ::profile::monitoring::munun::rrdcache
+  require ::profile::monitoring::munin::rrdcache
   contain ::profile::monitoring::munin::haproxy::balancermember
   include ::profile::monitoring::munin::plugin::snmp
 

--- a/manifests/monitoring/munin/server.pp
+++ b/manifests/monitoring/munin/server.pp
@@ -1,8 +1,15 @@
 # This class installs a munin server, and configures an apache virtuaø-host
 # responding to its name. 
 class profile::monitoring::munin::server {
-  $munin_urls = hiera('profile::munin::urls')
+  $munin_urls = lookup('profile::munin::urls', {
+    'value_type' => Array[Stdlib::Fqdn],
+  })
+  $max_processes = lookup('profile::munin::master::max_processes', {
+    'default_value' => 16,
+    'value_type'    => Integer,
+  })
 
+  require ::profile::monitoring::munun::rrdcache
   contain ::profile::monitoring::munin::haproxy::balancermember
   include ::profile::monitoring::munin::plugin::snmp
 
@@ -10,6 +17,8 @@ class profile::monitoring::munin::server {
     extra_config => [
       'cgiurl_graph /munin-cgi/munin-cgi-graph',
       'graph_data_size huge',
+      'rrdcached_socket /var/run/rrdcached.sock',
+      "max_processes ${max_processes}",
     ],
   }
 


### PR DESCRIPTION
Enable rrdcached for munin and make it possible to configure the amount of munin workers. rrdcached is "mandatory" if you want to have more workers than the default 16.