### PR TITLE
Logfix

### DIFF
--- a/manifests/baseconfig/logrotate.pp
+++ b/manifests/baseconfig/logrotate.pp
@@ -2,5 +2,8 @@
 class profile::baseconfig::logrotate {
   logrotate::conf { '/etc/logrotate.conf':
     compress => true,
+    su       => $::logrotate::params::default_su,
+    su_user  => $::logrotate::params::default_su_user,
+    su_group => $::logrotate::params::default_su_group,
   }
 }

--- a/manifests/baseconfig/logrotate.pp
+++ b/manifests/baseconfig/logrotate.pp
@@ -1,8 +1,9 @@
 # Class to set defaults for logrotate
 class profile::baseconfig::logrotate {
-  class { '::logrotate':
-    config             => {
-      compress => true,
-    }
-  }
+  include ::logrotate
+  #  class { '::logrotate':
+  #    config             => {
+  #      compress => true,
+  #    }
+  #  }
 }

--- a/manifests/baseconfig/logrotate.pp
+++ b/manifests/baseconfig/logrotate.pp
@@ -1,28 +1,18 @@
 # Class to set defaults for logrotate
 class profile::baseconfig::logrotate {
 
-  case $facts['os']['family'] {
-    'Debian': {
-      $default_su = $facts['os']['name'] ? {
-        'Ubuntu' => true,
-        default  => false,
-      }
-      $default_su_user = $facts['os']['name'] ? {
-        'Ubuntu' => 'root',
-        default  => undef,
-      }
-      $default_su_group = $facts['os']['name'] ? {
-        'Ubuntu'  => 'syslog',
-        default   => undef
-      }
-    }
-    default: {
-      $default_su = undef
-      $default_su_user = undef
-      $default_su_group = undef
-    }
+  $default_su = $facts['os']['name'] ? {
+    'Ubuntu' => true,
+    default  => false,
   }
-
+  $default_su_user = $facts['os']['name'] ? {
+    'Ubuntu' => 'root',
+    default  => undef,
+  }
+  $default_su_group = $facts['os']['name'] ? {
+    'Ubuntu' => 'syslog',
+    default  => undef,
+  }
 
   logrotate::conf { '/etc/logrotate.conf':
     compress => true,

--- a/manifests/baseconfig/logrotate.pp
+++ b/manifests/baseconfig/logrotate.pp
@@ -1,9 +1,6 @@
 # Class to set defaults for logrotate
 class profile::baseconfig::logrotate {
-  include ::logrotate
-  #  class { '::logrotate':
-  #    config             => {
-  #      compress => true,
-  #    }
-  #  }
+  logrotate::conf { '/etc/logrotate.conf':
+    compress => true,
+  }
 }

--- a/manifests/baseconfig/logrotate.pp
+++ b/manifests/baseconfig/logrotate.pp
@@ -1,9 +1,33 @@
 # Class to set defaults for logrotate
 class profile::baseconfig::logrotate {
 
-  contain ::logrotate::params
+  case $facts['os']['family'] {
+    'Debian': {
+      $default_su = $facts['os']['name'] ? {
+        'Ubuntu' => true,
+        default  => false,
+      }
+      $default_su_user = $facts['os']['name'] ? {
+        'Ubuntu' => 'root',
+        default  => undef,
+      }
+      $default_su_group = $facts['os']['name'] ? {
+        'Ubuntu'  => 'syslog',
+        default   => undef
+      }
+    }
+    default: {
+      $default_su = undef
+      $default_su_user = undef
+      $default_su_group = undef
+    }
+  }
+
 
   logrotate::conf { '/etc/logrotate.conf':
     compress => true,
+    su       => $default_su,
+    su_user  => $default_su_user,
+    su_group => $default_su_group,
   }
 }

--- a/manifests/baseconfig/logrotate.pp
+++ b/manifests/baseconfig/logrotate.pp
@@ -1,7 +1,7 @@
 # Class to set defaults for logrotate
 class profile::baseconfig::logrotate {
 
-  include ::logrotate::params
+  contain ::logrotate::params
 
   logrotate::conf { '/etc/logrotate.conf':
     compress => true,

--- a/manifests/baseconfig/logrotate.pp
+++ b/manifests/baseconfig/logrotate.pp
@@ -1,9 +1,9 @@
 # Class to set defaults for logrotate
 class profile::baseconfig::logrotate {
+
+  include ::logrotate::params
+
   logrotate::conf { '/etc/logrotate.conf':
     compress => true,
-    su       => $logrotate::params::default_su,
-    su_user  => $logrotate::params::default_su_user,
-    su_group => $logrotate::params::default_su_group,
   }
 }

--- a/manifests/baseconfig/logrotate.pp
+++ b/manifests/baseconfig/logrotate.pp
@@ -2,8 +2,8 @@
 class profile::baseconfig::logrotate {
   logrotate::conf { '/etc/logrotate.conf':
     compress => true,
-    su       => $::logrotate::params::default_su,
-    su_user  => $::logrotate::params::default_su_user,
-    su_group => $::logrotate::params::default_su_group,
+    su       => $logrotate::params::default_su,
+    su_user  => $logrotate::params::default_su_user,
+    su_group => $logrotate::params::default_su_group,
   }
 }


### PR DESCRIPTION
Ensure that the defaults for logroate.conf is sane for Ubuntu. Up until now it has not been able to rotate everything it is supposed to.