### PR TITLE
Systemd networkd socket buffer

### DIFF
--- a/files/systemd/networkd.socket.buffers.conf
+++ b/files/systemd/networkd.socket.buffers.conf
@@ -1,0 +1,2 @@
+[Socket]
+ReceiveBuffer=1024M

--- a/manifests/baseconfig/network/socketbuffer.pp
+++ b/manifests/baseconfig/network/socketbuffer.pp
@@ -2,14 +2,14 @@
 #   https://github.com/systemd/systemd/issues/14417
 class profile::baseconfig::network::socketbuffer {
   systemd::dropin_file { 'buffers.conf':
-    unit    => 'systemd-networkd.socket.d',
-    source  => 'puppet:///modules/profile/systemd/networkd.socket.buffers.conf',
-    notify  => Service['systemd-networkd.socket'], 
+    unit   => 'systemd-networkd.socket.d',
+    source => 'puppet:///modules/profile/systemd/networkd.socket.buffers.conf',
+    notify => Service['systemd-networkd.socket'],
   }
 
   service { 'systemd-networkd.socket':
     ensure   => 'running',
-    notify   => Exec['netplan_apply']
+    notify   => Exec['netplan_apply'],
     provider => 'systemd',
     require  => Systemd::Dropin_file['buffers.conf'],
   }

--- a/manifests/baseconfig/network/socketbuffer.pp
+++ b/manifests/baseconfig/network/socketbuffer.pp
@@ -1,0 +1,35 @@
+# Configure systemd-networkd.socket to avoid this bug:
+#   https://github.com/systemd/systemd/issues/14417
+class profile::baseconfig::network::socketbuffer {
+  include ::profile::systemd::reload
+
+  file { '/etc/systemd/system/systemd-networkd.socket.d/':
+    ensure => directory,
+    mode   => '0755',
+    owner  => root,
+    group  => root,
+  }
+
+  file { '/etc/systemd/system/systemd-networkd.socket.d/buffers.conf':
+    ensure  => file,
+    mode    => '0644',
+    owner   => root,
+    group   => root,
+    notify  => [
+      Exec['systemd-reload'],
+      Service['systemd-networkd.socket'],
+    ],
+    require => File['/etc/systemd/system/systemd-networkd.socket.d/'],
+    source  => 'puppet:///modules/profile/systemd/networkd.socket.buffers.conf',
+  }
+
+  service { 'systemd-networkd.socket':
+    ensure   => 'running',
+    notify   => Exec['netplan_apply']
+    provider => 'systemd',
+    require  => [
+      File['/etc/systemd/system/systemd-networkd.socket.d/buffers.conf'],
+      Exec['systemd-reload'],
+    ],
+  }
+}

--- a/manifests/baseconfig/network/socketbuffer.pp
+++ b/manifests/baseconfig/network/socketbuffer.pp
@@ -2,7 +2,7 @@
 #   https://github.com/systemd/systemd/issues/14417
 class profile::baseconfig::network::socketbuffer {
   systemd::dropin_file { 'buffers.conf':
-    unit   => 'systemd-networkd.socket.d',
+    unit   => 'systemd-networkd.socket',
     source => 'puppet:///modules/profile/systemd/networkd.socket.buffers.conf',
     notify => Service['systemd-networkd.socket'],
   }

--- a/manifests/baseconfig/network/socketbuffer.pp
+++ b/manifests/baseconfig/network/socketbuffer.pp
@@ -1,35 +1,16 @@
 # Configure systemd-networkd.socket to avoid this bug:
 #   https://github.com/systemd/systemd/issues/14417
 class profile::baseconfig::network::socketbuffer {
-  include ::profile::systemd::reload
-
-  file { '/etc/systemd/system/systemd-networkd.socket.d/':
-    ensure => directory,
-    mode   => '0755',
-    owner  => root,
-    group  => root,
-  }
-
-  file { '/etc/systemd/system/systemd-networkd.socket.d/buffers.conf':
-    ensure  => file,
-    mode    => '0644',
-    owner   => root,
-    group   => root,
-    notify  => [
-      Exec['systemd-reload'],
-      Service['systemd-networkd.socket'],
-    ],
-    require => File['/etc/systemd/system/systemd-networkd.socket.d/'],
+  systemd::dropin_file { 'buffers.conf':
+    unit    => 'systemd-networkd.socket.d',
     source  => 'puppet:///modules/profile/systemd/networkd.socket.buffers.conf',
+    notify  => Service['systemd-networkd.socket'], 
   }
 
   service { 'systemd-networkd.socket':
     ensure   => 'running',
     notify   => Exec['netplan_apply']
     provider => 'systemd',
-    require  => [
-      File['/etc/systemd/system/systemd-networkd.socket.d/buffers.conf'],
-      Exec['systemd-reload'],
-    ],
+    require  => Systemd::Dropin_file['buffers.conf'],
   }
 }

--- a/manifests/baseconfig/network/socketbuffer.pp
+++ b/manifests/baseconfig/network/socketbuffer.pp
@@ -4,13 +4,5 @@ class profile::baseconfig::network::socketbuffer {
   systemd::dropin_file { 'buffers.conf':
     unit   => 'systemd-networkd.socket',
     source => 'puppet:///modules/profile/systemd/networkd.socket.buffers.conf',
-    notify => Service['systemd-networkd.socket'],
-  }
-
-  service { 'systemd-networkd.socket':
-    ensure   => 'running',
-    notify   => Exec['netplan_apply'],
-    provider => 'systemd',
-    require  => Systemd::Dropin_file['buffers.conf'],
   }
 }

--- a/manifests/baseconfig/networking.pp
+++ b/manifests/baseconfig/networking.pp
@@ -1,6 +1,8 @@
 # This class configures the network interfaces of a node based on data from
 # hiera.
 class profile::baseconfig::networking {
+  include ::profile::baseconfig::network::socketbuffer
+
   # Configure interfaces as instructed in hiera.
   $if_to_configure = lookup('profile::baseconfig::network::interfaces', {
     'default_value' => false,
@@ -38,6 +40,7 @@ class profile::baseconfig::networking {
     # If the bridge should have an external connection
     if($configuration['external']) {
       if($configuration['external']['mtu']) {
+        # TODO: This should really just be $configuration['mtu']?
         $mtu = $configuration['external']['mtu']
       } else {
         $mtu = 1500


### PR DESCRIPTION
To avoid issues with many network interfaces, add a systemd dropin-file to allow systmd-networkd.socket use more memory for some buffers.