### PR TITLE
Yoga, Memcache-sudo, apt proposed

### DIFF
--- a/files/sudo/memcache_sudoers
+++ b/files/sudo/memcache_sudoers
@@ -1,0 +1,5 @@
+# Allow administrator to start/stop/restart the memcached service 
+%administrator ALL=(root) /usr/bin/systemctl stop memcached 
+%administrator ALL=(root) NOPASSWD: /usr/bin/systemctl start memcached 
+%administrator ALL=(root) NOPASSWD: /usr/bin/systemctl restart memcached 
+%administrator ALL=(root) NOPASSWD: /usr/bin/systemctl status memcached 

--- a/manifests/apt/proposed.pp
+++ b/manifests/apt/proposed.pp
@@ -14,6 +14,9 @@ class profile::apt::proposed {
     location => 'http://archive.ubuntu.com/ubuntu/',
     release  => "${distro}-proposed",
     repos    => 'main universe',
-    pin      => 400,
+    pin      => {
+      priority => 400,
+      release  => "${distro}-proposed",
+    },
   }
 }

--- a/manifests/apt/proposed.pp
+++ b/manifests/apt/proposed.pp
@@ -3,7 +3,7 @@
 class profile::apt::proposed {
   $distro = lookup('profile::apt::proposed::distro', {
     'default_value' => $::facts['os']['distro']['codename'], 
-    'value_type'    => Integer,
+    'value_type'    => String,
   })
   $pin = lookup('profile::apt::proposed::pin', {
     'default_value' => 400, 

--- a/manifests/apt/proposed.pp
+++ b/manifests/apt/proposed.pp
@@ -1,0 +1,19 @@
+# Enabled the apt-proposed repositories with a low priority, so that some
+# packages can be installed from it.
+class profile::apt::proposed {
+  $distro = lookup('profile::apt::proposed::distro', {
+    'default_value' => $::facts['os']['distro']['codename'], 
+    'value_type'    => Integer,
+  })
+  $pin = lookup('profile::apt::proposed::pin', {
+    'default_value' => 400, 
+    'value_type'    => Integer,
+  })
+
+  apt::source { 'ubuntu-proposed':
+    location => 'http://archive.ubuntu.com/ubuntu/',
+    release  => "${distro}-proposed"
+    repos    => 'main universe',
+    pin      => 400,
+  }
+}

--- a/manifests/apt/proposed.pp
+++ b/manifests/apt/proposed.pp
@@ -12,7 +12,7 @@ class profile::apt::proposed {
 
   apt::source { 'ubuntu-proposed':
     location => 'http://archive.ubuntu.com/ubuntu/',
-    release  => "${distro}-proposed"
+    release  => "${distro}-proposed",
     repos    => 'main universe',
     pin      => 400,
   }

--- a/manifests/monitoring/munin/plugin/vgpu.pp
+++ b/manifests/monitoring/munin/plugin/vgpu.pp
@@ -18,7 +18,7 @@ class profile::monitoring::munin::plugin::vgpu {
     'default_value' => '',
   })
 
-  $gpus = lookup('nova::compute::vgpu::vgpu_types_device_addresses_mapping')
+  $gpus = lookup('nova::compute::mdev::mdev_types')
 
   $plugins = [
     'vgpu_memory',
@@ -38,8 +38,8 @@ class profile::monitoring::munin::plugin::vgpu {
     }
   }
 
-  $config_data = flatten($gpus.map | $vgpu_type, $addresses | {
-    $addresses.map | $address | {
+  $config_data = flatten($gpus.map | $vgpu_type, $data | {
+    $data['device_addresses'].map | $address | {
       $id = fqdn_rand(999, "${address} ${vgpu_type}")
       "env.GPU${id} ${address} ${vgpu_type}"
     }

--- a/manifests/services/memcache.pp
+++ b/manifests/services/memcache.pp
@@ -38,6 +38,7 @@ class profile::services::memcache {
   }
 
   contain ::profile::services::memcache::firewall
+  include ::profile::services::memcache::sudo
 
   class { 'memcached':
     pidfile    => '/var/run/memcached/memcached.pid',

--- a/manifests/services/memcache/sudo.pp
+++ b/manifests/services/memcache/sudo.pp
@@ -1,0 +1,7 @@
+# sudo config for memcache administration
+class profile::services::memcache::sudo {
+  sudo::conf { 'memcache':
+    priority => 50,
+    source   => 'puppet:///modules/profile/sudo/memcache_sudoers',
+  }
+}


### PR DESCRIPTION
# New features

 - Sudo-config for the memcache-service; to allow passwordless restart/status/start of the service. A stop requires auth.
 - Munin-config to monitor nova vgpu's.
 - APT-config adding the ubuntu proposed repos with a low priority, so that we can install specific packages from there if the required versions are unavailable in the regular repo.

# Hiera changes

 - `nova::compute::mdev::mdev_types` - Replaces the `nova::compute::vgpu::vgpu_types_device_addresses_mapping` key. The hiera-key gives the required parameters for setting up munin to monitor vgpu's. For details, look at the yoga-release of ntnuopenstack.
 - `profile::apt::proposed::distro`: An optional key to help apt configure the correct proposed repo. Defaults to the distro codename fact.
 - `profile::apt::proposed::pin`: An optional key to set the priority of the proposed repo. Defaults to 400.