### PR TITLE
Optional sudo-distribution, less secrets in logs and disabling intel-pt

### DIFF
--- a/files/libvirt/cpu/x86_Icelake-Server-NTNU.xml
+++ b/files/libvirt/cpu/x86_Icelake-Server-NTNU.xml
@@ -37,7 +37,7 @@
     <feature name='fsgsbase'/>
     <feature name='fxsr'/>
     <feature name='gfni'/>
-    <feature name='intel-pt'/>
+    <feature name='intel-pt' removed='yes'/>
     <feature name='invpcid'/>
     <feature name='la57'/>
     <feature name='lahf_lm'/>

--- a/files/sudo/cephosd_sudoers
+++ b/files/sudo/cephosd_sudoers
@@ -3,3 +3,7 @@
 
 # Allow administrator to use various ceph commands without password
 %administrator ALL=(root) NOPASSWD: /usr/sbin/ceph-volume inventory
+
+## allow ceph daemons (which run as user ceph) to collect device health metrics
+ceph ALL=NOPASSWD: /usr/sbin/smartctl -x --json=o /dev/*
+ceph ALL=NOPASSWD: /usr/sbin/nvme * smart-log-add --json /dev/*

--- a/manifests/baseconfig/sudo.pp
+++ b/manifests/baseconfig/sudo.pp
@@ -1,6 +1,23 @@
 # This class starts to configure sudo
 class profile::baseconfig::sudo {
-  class { '::sudo': }
+  # if purge::unmanaged is true we should purge all files in sudoers.d that is
+  # not managed by puppet. If it is false we will only purge files with the
+  # puppet-prefix (ie: files previously managed by puppet).
+  $purge = lookup('profile::baseconfig::sudo::purge::unmanaged', {
+    'default_value' => true,
+    'value_type'    => Boolean,
+  })
+
+  if($purge) {
+    $opts = {}
+  } else {
+    $opts = { 'purge_ignore' => '[!puppet_]*' }
+  }
+
+  class { '::sudo':
+    prefix => 'puppet_',
+    *      => $opts,
+  }
 
   sudo::conf { 'insults':
     priority => 10,

--- a/manifests/services/haproxy/web.pp
+++ b/manifests/services/haproxy/web.pp
@@ -116,10 +116,11 @@ class profile::services::haproxy::web {
 
   if ($certificate) {
     file { $certfile:
-      ensure  => 'present',
-      content => $certificate,
-      mode    => '0600',
-      notify  => Service['haproxy'],
+      ensure    => 'present',
+      content   => $certificate,
+      mode      => '0600',
+      notify    => Service['haproxy'],
+      show_diff => false,
     }
   }
 }


### PR DESCRIPTION
This merge bring in the following changes:

- intel-pt is disabled in the Icelke-Server-NTNU template for libvirt
- Ceph is allowed to collect device-metrics
- Purging of unmanaged sudo-config is now optional, and is controlled by the hiera-key `profile::baseconfig::sudo::purge::unmanaged`.
- Haproxy-certs+keys are not longer showed in full in the puppet-logs.