### PR TITLE
Keep fewer mysql-backups, and make backups opt-out-able.

### DIFF
--- a/files/mysql/mysqlbackupclean.py
+++ b/files/mysql/mysqlbackupclean.py
@@ -43,10 +43,10 @@ for f in files:
     lastDaily = match.group(3)
     daily.append(f)
 
-keep = every[-12:]
-daily = daily[-14:]
-monthly = monthly[-12:]
-yearly = yearly[-5:]
+keep = every[-10:]
+daily = daily[-10:]
+monthly = []
+yearly = []
 
 toDelete = [x for x in every if x not in keep and x not in daily \
     and x not in monthly and x not in yearly]

--- a/manifests/services/mysql/backup.pp
+++ b/manifests/services/mysql/backup.pp
@@ -6,54 +6,63 @@ class profile::services::mysql::backup {
   })
   $schedule = lookup('profile::mysql::backup::schedule', {
     'default_value' => 'trihoral',
-    'value_type'    => Enum['trihoral', 'daily', 'weekly'],
+    'value_type'    => Enum['trihoral', 'daily', 'weekly', 'off'],
   })
 
-  include ::profile::services::mysql::backup::scripts
-
-  case $schedule {
-    # Run every three hours
-    'trihoral': {
-      $hour = '*/3'
-      $day = '*'
+  if($schedule == 'off') {
+    cron { 'Mysql database backup':
+      ensure => absent,
     }
-
-    # Run daily at a random time within 00:00 and 06:59
-    'daily': {
-      $hour = fqdn_rand(6)
-      $day = '*'
+    cron { 'Mysql database backup cleaning':
+      ensure => absent,
     }
-
-    # Run at sundays at a random time within 00:00 and 06:59
-    'weekly': {
-      $hour = fqdn_rand(6)
-      $day = '0'
-    }
-  }
-
-  if ($external_backup) {
-    include ::profile::zabbix::agent::mysql
-
-    $backup_command = '/usr/local/sbin/mysqlbackup-remote.sh'
-    $clean_command = '/usr/local/sbin/mysqlbackupclean-remote.sh'
   } else {
-    $backup_command = '/usr/local/sbin/mysqlbackup.sh'
-    $clean_command = '/usr/local/sbin/mysqlbackupclean.py /var/backups'
-  }
+    include ::profile::services::mysql::backup::scripts
 
-  cron { 'Mysql database backup':
-    command => $backup_command, 
-    hour    => $hour, 
-    minute  => fqdn_rand(60, "${::hostname}-backup"), 
-    user    => 'root',
-    weekday => $day,
-  }
+    case $schedule {
+      # Run every three hours
+      'trihoral': {
+        $hour = '*/3'
+        $day = '*'
+      }
 
-  cron { 'Mysql database backup cleaning':
-    command => $clean_command, 
-    hour    => fqdn_rand(6) + 8, 
-    minute  => fqdn_rand(60, "${::hostname}-cleaning"), 
-    user    => 'root',
-    weekday => $day,
+      # Run daily at a random time within 00:00 and 06:59
+      'daily': {
+        $hour = fqdn_rand(6)
+        $day = '*'
+      }
+
+      # Run at sundays at a random time within 00:00 and 06:59
+      'weekly': {
+        $hour = fqdn_rand(6)
+        $day = '0'
+      }
+    }
+
+    if ($external_backup) {
+      include ::profile::zabbix::agent::mysql
+
+      $backup_command = '/usr/local/sbin/mysqlbackup-remote.sh'
+      $clean_command = '/usr/local/sbin/mysqlbackupclean-remote.sh'
+    } else {
+      $backup_command = '/usr/local/sbin/mysqlbackup.sh'
+      $clean_command = '/usr/local/sbin/mysqlbackupclean.py /var/backups'
+    }
+
+    cron { 'Mysql database backup':
+      command => $backup_command, 
+      hour    => $hour, 
+      minute  => fqdn_rand(60, "${::hostname}-backup"), 
+      user    => 'root',
+      weekday => $day,
+    }
+
+    cron { 'Mysql database backup cleaning':
+      command => $clean_command, 
+      hour    => fqdn_rand(6) + 8, 
+      minute  => fqdn_rand(60, "${::hostname}-cleaning"), 
+      user    => 'root',
+      weekday => $day,
+    }
   }
 }


### PR DESCRIPTION
Changed the retention of mysql-backups to "last 10 backups plus the first backup the last 10 days" to avoid storing too many old backups.

Also made the backups opt-out-able by setting the key `profile::mysql::backup::schedule` to `off`.