### PR TITLE
MySQL: Legg remote-backup på ramdisk

### DIFF
--- a/files/mysql/mysqlbackup-remote.sh
+++ b/files/mysql/mysqlbackup-remote.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-location="/var/backups"
+location="/dev/shm"
 share='/mnt/backup'
 filename="${location}/MysqlDump.$(date +%y%m%d%H%M%S).sql.gz"
 


### PR DESCRIPTION
## Changes

- mysqlbackup-remote.sh lagrer backupen i /dev/shm (tmpfs), heller enn på disk

## Hiera

Ingen endring.