### PR TITLE
Allow override the max-connections config

### DIFF
--- a/manifests/services/mysql/cluster.pp
+++ b/manifests/services/mysql/cluster.pp
@@ -15,6 +15,11 @@ class profile::services::mysql::cluster {
   })
   $mariadb_version = lookup('profile::mysqlcluster::mariadb::version', String)
 
+  $max_connections = lookup('profile::mysqlcluster::max_connections', {
+    'default_value' => 1000,
+    'value_type'    => Integer,
+  })
+
   # Determine the management-IP for the server; either through the now obsolete
   # hiera-keys, or through the sl2-data:
   #  TODO: Remove the old-fashioned lookups. 
@@ -59,7 +64,7 @@ class profile::services::mysql::cluster {
       'mysqld'                   => {
         'port'                   => '3306',
         'bind-address'           => $management_ip,
-        'max_connections'        => '1000',
+        'max_connections'        => $max_connections,
         'net_read_timeout'       => $net_read_timeout,
         'net_write_timeout'      => $net_write_timeout,
         'ssl-disable'            => true,


### PR DESCRIPTION
Allow setting the max connections for mysql.

# Optional hiera-keys:

 - `profile::mysqlcluster::max_connections` - Number of connections allowed (defaults to 1000).