### PR TITLE
Ceph Squid and puppet aliases

### DIFF
--- a/manifests/baseconfig.pp
+++ b/manifests/baseconfig.pp
@@ -1,5 +1,6 @@
 # This class ensures that all baseconfiguration are brought in.
 class profile::baseconfig {
+  include ::profile::baseconfig::alias
   include ::profile::baseconfig::disk
   include ::profile::baseconfig::facts
   include ::profile::baseconfig::git

--- a/manifests/baseconfig.pp
+++ b/manifests/baseconfig.pp
@@ -1,6 +1,5 @@
 # This class ensures that all baseconfiguration are brought in.
 class profile::baseconfig {
-  include ::profile::baseconfig::alias
   include ::profile::baseconfig::disk
   include ::profile::baseconfig::facts
   include ::profile::baseconfig::git

--- a/manifests/baseconfig/alias.pp
+++ b/manifests/baseconfig/alias.pp
@@ -8,13 +8,21 @@ define profile::baseconfig::alias (
     $filename = "/home/${username}/.bash_aliases"
   }
 
+  file { $filename:
+    ensure => present,
+    owner => $username, 
+    mode  => 0644,
+  }
+
   $caserver = lookup('profile::puppet::caserver')
   file_line { "Alias pca for ${username}":
-    path => $filename,
-    line => "alias pca='sudo puppet agent --test --server ${caserver}'",
+    path    => $filename,
+    line    => "alias pca='sudo puppet agent --test --server ${caserver}'",
+    require => File[$filename],
   }
   file_line { "Alias pat for ${username}":
-    path => $filename,
-    line => "alias pat='sudo puppet agent --test",
+    path    => $filename,
+    line    => "alias pat='sudo puppet agent --test",
+    require => File[$filename],
   }
 }

--- a/manifests/baseconfig/alias.pp
+++ b/manifests/baseconfig/alias.pp
@@ -22,7 +22,7 @@ define profile::baseconfig::alias (
   }
   file_line { "Alias pat for ${username}":
     path    => $filename,
-    line    => "alias pat='sudo puppet agent --test",
+    line    => "alias pat='sudo puppet agent --test'",
     require => File[$filename],
   }
 }

--- a/manifests/baseconfig/alias.pp
+++ b/manifests/baseconfig/alias.pp
@@ -11,7 +11,7 @@ define profile::baseconfig::alias (
   file { $filename:
     ensure => present,
     owner => $username, 
-    mode  => 0644,
+    mode  => '0644',
   }
 
   $caserver = lookup('profile::puppet::caserver')

--- a/manifests/baseconfig/alias.pp
+++ b/manifests/baseconfig/alias.pp
@@ -1,0 +1,20 @@
+# Configures useful aliases for a certain user.
+define profile::baseconfig::alias (
+  String $username = $name,
+) {
+  if($username == 'root') {
+    $filename = '/root/.bash_aliases'
+  } else {
+    $filename = "/home/${username}/.bash_aliases"
+  }
+
+  $caserver = lookup('profile::puppet::caserver')
+  file_line { "Alias pca for ${username}":
+    path => $filename,
+    line => "alias pca='sudo puppet agent --test --server ${caserver}'",
+  }
+  file_line { "Alias pat for ${username}":
+    path => $filename,
+    line => "alias pat='sudo puppet agent --test",
+  }
+}

--- a/manifests/baseconfig/users.pp
+++ b/manifests/baseconfig/users.pp
@@ -33,6 +33,10 @@ class profile::baseconfig::users {
       shell          => '/bin/bash',
       uid            => $data['uid'],
     }
+    
+    ::profile::baseconfig::alias { $username : 
+      require => User[$username],
+    }
 
     if ( $ensure == 'present' ) {
       file { "${homedir}/.ssh":
@@ -53,6 +57,8 @@ class profile::baseconfig::users {
       }
     }
   }
+
+  ::profile::baseconfig::alias { 'root' : }
 
   # Modify root's attributes
   file { '/root/.ssh':

--- a/manifests/ceph/repo.pp
+++ b/manifests/ceph/repo.pp
@@ -1,6 +1,7 @@
 # Abstraction for the ceph::repo class
 class profile::ceph::repo {
-  if($::facts['os']['distro']['codename'] == 'jammy') {
+  $release = lookup('ceph::params::release')
+  if($::facts['os']['distro']['codename'] == 'jammy' and $release == 'quincy') {
     $default = 'absent'
   } else {
     $default = 'present'


### PR DESCRIPTION
This release bring in the following changes:

- Configure repos for ceph on Jammy if the version is not quincy (Quincy is the default version for jammy).
- Add aliases for puppet runs 
--- "pat" for regular puppet run
--- "pca" to run puppet from the puppetca