### PR TITLE
Oppgraderingsalias

### DIFF
--- a/manifests/baseconfig/alias.pp
+++ b/manifests/baseconfig/alias.pp
@@ -20,7 +20,7 @@ define profile::baseconfig::alias (
     mode   => '0644',
   }
   concat_fragment { "Puppet-heading in ${filename}":
-    content => '# This file is managed by puppet.\n',
+    content => "# This file is managed by puppet.\n",
     order   => 1,
     target  => $filename,
   }

--- a/manifests/baseconfig/alias.pp
+++ b/manifests/baseconfig/alias.pp
@@ -6,7 +6,7 @@ define profile::baseconfig::alias (
     $filename = '/root/.bash_aliases'
 
     concat_fragment { "Alias oppgrader in ${filename}":
-      content => "alias pca='sudo puppet agent --test --server ${caserver}'\n",
+      content => "apt update && DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a apt -y dist-upgrade && apt -y autoremove",
       target  => $filename,
     }
   } else {
@@ -26,7 +26,7 @@ define profile::baseconfig::alias (
     target  => $filename,
   }
   concat_fragment { "Alias pat in ${filename}":
-    content => "alias pca='sudo puppet agent --test --server ${caserver}'\n",
+    content => "alias pca='sudo puppet agent --test'\n",
     target  => $filename,
   }
 }

--- a/manifests/baseconfig/alias.pp
+++ b/manifests/baseconfig/alias.pp
@@ -20,7 +20,7 @@ define profile::baseconfig::alias (
     mode   => '0644',
   }
   concat_fragment { "Puppet-heading in ${filename}":
-    content => '# This file is managed by puppet.',
+    content => '# This file is managed by puppet.\n',
     order   => 1,
     target  => $filename,
   }

--- a/manifests/baseconfig/alias.pp
+++ b/manifests/baseconfig/alias.pp
@@ -6,7 +6,7 @@ define profile::baseconfig::alias (
     $filename = '/root/.bash_aliases'
 
     concat_fragment { "Alias oppgrader in ${filename}":
-      content => "alias oppgrader='apt update && DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a apt -y dist-upgrade && apt -y autoremove'",
+      content => "alias oppgrader='apt update && DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a apt -y dist-upgrade && apt -y autoremove'\n",
       target  => $filename,
     }
   } else {

--- a/manifests/baseconfig/alias.pp
+++ b/manifests/baseconfig/alias.pp
@@ -4,25 +4,29 @@ define profile::baseconfig::alias (
 ) {
   if($username == 'root') {
     $filename = '/root/.bash_aliases'
+
+    concat_fragment { "Alias oppgrader in ${filename}":
+      content => "alias pca='sudo puppet agent --test --server ${caserver}'",
+      target  => $filename,
+    }
   } else {
     $filename = "/home/${username}/.bash_aliases"
   }
 
-  file { $filename:
+  concat { $filename:
     ensure => present,
-    owner => $username, 
-    mode  => '0644',
+    owner  => $username,
+    group  => ($username == 'root') ? 'root' : 'users',
+    mode   => '0644',
   }
 
   $caserver = lookup('profile::puppet::caserver')
-  file_line { "Alias pca for ${username}":
-    path    => $filename,
-    line    => "alias pca='sudo puppet agent --test --server ${caserver}'",
-    require => File[$filename],
+  concat_fragment { "Alias pca in ${filename}":
+    content => "alias pca='sudo puppet agent --test --server ${caserver}'",
+    target  => $filename,
   }
-  file_line { "Alias pat for ${username}":
-    path    => $filename,
-    line    => "alias pat='sudo puppet agent --test'",
-    require => File[$filename],
+  concat_fragment { "Alias pat in ${filename}":
+    content => "alias pca='sudo puppet agent --test --server ${caserver}'",
+    target  => $filename,
   }
 }

--- a/manifests/baseconfig/alias.pp
+++ b/manifests/baseconfig/alias.pp
@@ -19,6 +19,11 @@ define profile::baseconfig::alias (
     group  => ($username) ? { 'root' => 'root', default => 'users'},
     mode   => '0644',
   }
+  concat_fragment { "Puppet-heading in ${filename}":
+    content => '# This file is managed by puppet.',
+    order   => 1,
+    target  => $filename,
+  }
 
   $caserver = lookup('profile::puppet::caserver')
   concat_fragment { "Alias pca in ${filename}":

--- a/manifests/baseconfig/alias.pp
+++ b/manifests/baseconfig/alias.pp
@@ -6,7 +6,7 @@ define profile::baseconfig::alias (
     $filename = '/root/.bash_aliases'
 
     concat_fragment { "Alias oppgrader in ${filename}":
-      content => "apt update && DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a apt -y dist-upgrade && apt -y autoremove",
+      content => "alias oppgrader='apt update && DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a apt -y dist-upgrade && apt -y autoremove'",
       target  => $filename,
     }
   } else {

--- a/manifests/baseconfig/alias.pp
+++ b/manifests/baseconfig/alias.pp
@@ -26,7 +26,7 @@ define profile::baseconfig::alias (
     target  => $filename,
   }
   concat_fragment { "Alias pat in ${filename}":
-    content => "alias pca='sudo puppet agent --test'\n",
+    content => "alias pat='sudo puppet agent --test'\n",
     target  => $filename,
   }
 }

--- a/manifests/baseconfig/alias.pp
+++ b/manifests/baseconfig/alias.pp
@@ -6,7 +6,7 @@ define profile::baseconfig::alias (
     $filename = '/root/.bash_aliases'
 
     concat_fragment { "Alias oppgrader in ${filename}":
-      content => "alias pca='sudo puppet agent --test --server ${caserver}'",
+      content => "alias pca='sudo puppet agent --test --server ${caserver}'\n",
       target  => $filename,
     }
   } else {
@@ -22,11 +22,11 @@ define profile::baseconfig::alias (
 
   $caserver = lookup('profile::puppet::caserver')
   concat_fragment { "Alias pca in ${filename}":
-    content => "alias pca='sudo puppet agent --test --server ${caserver}'",
+    content => "alias pca='sudo puppet agent --test --server ${caserver}'\n",
     target  => $filename,
   }
   concat_fragment { "Alias pat in ${filename}":
-    content => "alias pca='sudo puppet agent --test --server ${caserver}'",
+    content => "alias pca='sudo puppet agent --test --server ${caserver}'\n",
     target  => $filename,
   }
 }

--- a/manifests/baseconfig/alias.pp
+++ b/manifests/baseconfig/alias.pp
@@ -16,7 +16,7 @@ define profile::baseconfig::alias (
   concat { $filename:
     ensure => present,
     owner  => $username,
-    group  => ($username == 'root') ? 'root' : 'users',
+    group  => ($username) ? { 'root' => 'root', default => 'users'},
     mode   => '0644',
   }
 


### PR DESCRIPTION
### Changes

- Refactoring the alias config to use concat instead of file_lines. This helps puppet manage the whole file.
- Adding an alias **oppgrader** to the root user which basically runs apt update, upgrade and auto-remove without waiting for user-input.