### PR TITLE
Haproxydiscovery

### DIFF
--- a/manifests/services/haproxy/firewall.pp
+++ b/manifests/services/haproxy/firewall.pp
@@ -1,6 +1,13 @@
 # Default firewall rules for the haproxy status-page
 class profile::services::haproxy::firewall {
+  # Let our admin-clients see the statuspage
   ::profile::firewall::management::external { 'haproxy-status':
     port => 9000,
+  }
+
+  # Let our zabbix-servers discover the service
+  ::profile::firewall::management::custom { 'haproxy-status-infra':
+    port      => 9000,
+    hiera_key => 'profile::zabbix::agent::servers',
   }
 }

--- a/manifests/services/haproxy/firewall.pp
+++ b/manifests/services/haproxy/firewall.pp
@@ -6,7 +6,7 @@ class profile::services::haproxy::firewall {
   }
 
   # Let our zabbix-servers discover the service
-  ::profile::firewall::management::custom { 'haproxy-status-infra':
+  ::profile::firewall::custom { 'haproxy-status-infra':
     port      => 9000,
     hiera_key => 'profile::zabbix::agent::servers',
   }


### PR DESCRIPTION
Open the firewall so that our zabbix-servers can reach the haproxy statuspage. This is used by zabbix to automatically discover the haproxy service.