### PR TITLE
Tuning of the MySQL-clusters.

### DIFF
--- a/manifests/services/mysql/cluster.pp
+++ b/manifests/services/mysql/cluster.pp
@@ -23,6 +23,11 @@ class profile::services::mysql::cluster {
     'value_type'    => Integer,
   })
 
+  $innodb_buffer_pool_size = lookup('profile::mysql::innodb_buffer_pool_size', {
+    'default_value' => 1073741824, # We default to 1GB. 
+    'value_type'    => Integer, 
+  })
+
   # Determine the management-IP for the server; either through the now obsolete
   # hiera-keys, or through the sl2-data:
   #  TODO: Remove the old-fashioned lookups. 
@@ -63,14 +68,15 @@ class profile::services::mysql::cluster {
     status_check        => false,
     validate_connection => false,
     override_options    => {
-      'mysqld'                   => {
-        'port'                   => '3306',
-        'bind-address'           => $management_ip,
-        'max_connections'        => $max_connections,
-        'net_read_timeout'       => $net_read_timeout,
-        'net_write_timeout'      => $net_write_timeout,
-        'ssl-disable'            => true,
-        'wsrep_provider_options' => '"gcache.size=2G"',
+      'mysqld'                    => {
+        'port'                    => '3306',
+        'bind-address'            => $management_ip,
+        'innodb_buffer_pool_size' => $innodb_buffer_pool_size, 
+        'max_connections'         => $max_connections,
+        'net_read_timeout'        => $net_read_timeout,
+        'net_write_timeout'       => $net_write_timeout,
+        'ssl-disable'             => true,
+        'wsrep_provider_options'  => '"gcache.size=2G"',
       }
     },
     require             => [

--- a/manifests/services/mysql/cluster.pp
+++ b/manifests/services/mysql/cluster.pp
@@ -94,7 +94,11 @@ class profile::services::mysql::cluster {
         'max_heap_table_size'     => $max_heap_table_size,
         'net_read_timeout'        => $net_read_timeout,
         'net_write_timeout'       => $net_write_timeout,
-        'ssl-disable'             => true,
+        'ssl_ca'                  => '/etc/puppetlabs/puppet/ssl/certs/ca.pem',
+        'ssl_cert'                =>
+          "/etc/puppetlabs/puppet/ssl/certs/${::fqdn}.pem",
+        'ssl_key'                 =>
+          "/etc/puppetlabs/puppet/ssl/private_keys/${::fqdn}.pem",
         'thread_handling'         => $thread_handling,
         'thread_pool_size'        => $thread_pool_size,
         'tmp_table_size'          => $tmp_table_size,

--- a/manifests/services/mysql/cluster.pp
+++ b/manifests/services/mysql/cluster.pp
@@ -44,6 +44,9 @@ class profile::services::mysql::cluster {
   $tmp_table_size = lookup('profile::mysql::tmp_table_size', {
     'default_value' => '64M',
   })
+  $gcache_size = lookup('profile::mysql::wsrep::gcache', {
+    'default_value' => '2G',
+  })
 
   # Determine the management-IP for the server; either through the now obsolete
   # hiera-keys, or through the sl2-data:
@@ -98,7 +101,7 @@ class profile::services::mysql::cluster {
         'thread_handling'         => $thread_handling,
         'thread_pool_size'        => $thread_pool_size,
         'tmp_table_size'          => $tmp_table_size,
-        'wsrep_provider_options'  => '"gcache.size=2G"',
+        'wsrep_provider_options'  => "\"gcache.size=${gcache_size}\"",
       }
     },
     require             => [

--- a/manifests/services/mysql/cluster.pp
+++ b/manifests/services/mysql/cluster.pp
@@ -24,8 +24,8 @@ class profile::services::mysql::cluster {
   })
 
   $innodb_buffer_pool_size = lookup('profile::mysql::innodb_buffer_pool_size', {
-    'default_value' => 1073741824, # We default to 1GB. 
-    'value_type'    => Integer,
+    'default_value' => '1G',
+    'value_type'    => Variant[String, Integer],
   })
   $thread_handling = lookup('profile::mysql::thread_handling', {
     'default_value' => 'pool-of-threads',

--- a/manifests/services/mysql/cluster.pp
+++ b/manifests/services/mysql/cluster.pp
@@ -27,6 +27,23 @@ class profile::services::mysql::cluster {
     'default_value' => 1073741824, # We default to 1GB. 
     'value_type'    => Integer,
   })
+  $thread_handling = lookup('profile::mysql::thread_handling', {
+    'default_value' => 'pool-of-threads',
+    'value_type'    => String,
+  })
+  $thread_pool_size = lookup('profile::mysql::thread_pool_size', {
+    'default_value' => $facts['processors']['count'],
+    'value_type'    => Integer,
+  })
+  $key_buffer_size = lookup('profile::mysql::key_buffer_size', {
+    'default_value' => '64M',
+  })
+  $max_heap_table_size = lookup('profile::mysql::max_heap_table_size', {
+    'default_value' => '64M',
+  })
+  $tmp_table_size = lookup('profile::mysql::tmp_table_size', {
+    'default_value' => '64M',
+  })
 
   # Determine the management-IP for the server; either through the now obsolete
   # hiera-keys, or through the sl2-data:
@@ -72,10 +89,15 @@ class profile::services::mysql::cluster {
         'port'                    => '3306',
         'bind-address'            => $management_ip,
         'innodb_buffer_pool_size' => $innodb_buffer_pool_size,
+        'key_buffer_size'         => $key_buffer_size,
         'max_connections'         => $max_connections,
+        'max_heap_table_size'     => $max_heap_table_size,
         'net_read_timeout'        => $net_read_timeout,
         'net_write_timeout'       => $net_write_timeout,
         'ssl-disable'             => true,
+        'thread_handling'         => $thread_handling,
+        'thread_pool_size'        => $thread_pool_size,
+        'tmp_table_size'          => $tmp_table_size,
         'wsrep_provider_options'  => '"gcache.size=2G"',
       }
     },

--- a/manifests/services/mysql/cluster.pp
+++ b/manifests/services/mysql/cluster.pp
@@ -25,7 +25,7 @@ class profile::services::mysql::cluster {
 
   $innodb_buffer_pool_size = lookup('profile::mysql::innodb_buffer_pool_size', {
     'default_value' => 1073741824, # We default to 1GB. 
-    'value_type'    => Integer, 
+    'value_type'    => Integer,
   })
 
   # Determine the management-IP for the server; either through the now obsolete
@@ -71,7 +71,7 @@ class profile::services::mysql::cluster {
       'mysqld'                    => {
         'port'                    => '3306',
         'bind-address'            => $management_ip,
-        'innodb_buffer_pool_size' => $innodb_buffer_pool_size, 
+        'innodb_buffer_pool_size' => $innodb_buffer_pool_size,
         'max_connections'         => $max_connections,
         'net_read_timeout'        => $net_read_timeout,
         'net_write_timeout'       => $net_write_timeout,

--- a/manifests/services/mysql/cluster.pp
+++ b/manifests/services/mysql/cluster.pp
@@ -94,11 +94,7 @@ class profile::services::mysql::cluster {
         'max_heap_table_size'     => $max_heap_table_size,
         'net_read_timeout'        => $net_read_timeout,
         'net_write_timeout'       => $net_write_timeout,
-        'ssl_ca'                  => '/etc/puppetlabs/puppet/ssl/certs/ca.pem',
-        'ssl_cert'                =>
-          "/etc/puppetlabs/puppet/ssl/certs/${::fqdn}.pem",
-        'ssl_key'                 =>
-          "/etc/puppetlabs/puppet/ssl/private_keys/${::fqdn}.pem",
+        'ssl-disable'             => true,
         'thread_handling'         => $thread_handling,
         'thread_pool_size'        => $thread_pool_size,
         'tmp_table_size'          => $tmp_table_size,

--- a/manifests/services/mysql/standalone.pp
+++ b/manifests/services/mysql/standalone.pp
@@ -14,7 +14,7 @@ class profile::services::mysql::standalone {
   })
   $innodb_buffer_pool_size = lookup('profile::mysql::innodb_buffer_pool_size', {
     'default_value' => 1073741824, # We default to 1GB. 
-    'value_type'    => Integer, 
+    'value_type'    => Integer,
   })
 
   $zabbix_servers = lookup('profile::zabbix::agent::servers', {
@@ -40,15 +40,15 @@ class profile::services::mysql::standalone {
     override_options        => {
       'mysqld'                    => {
         'port'                    => '3306',
-        'bind-address'            => 
-          $::sl2['server']['primary_interface']['ipv4'], 
-        'innodb_buffer_pool_size' => $innodb_buffer_pool_size, 
+        'bind-address'            =>
+          $::sl2['server']['primary_interface']['ipv4'],
+        'innodb_buffer_pool_size' => $innodb_buffer_pool_size,
         'max_connections'         => '750',
         'net_read_timeout'        => $net_read_timeout,
         'net_write_timeout'       => $net_write_timeout,
         'ssl_ca'                  => '/etc/puppetlabs/puppet/ssl/certs/ca.pem',
-        'ssl_cert'                => 
-          "/etc/puppetlabs/puppet/ssl/certs/${fqdn}.pem",
+        'ssl_cert'                =>
+          "/etc/puppetlabs/puppet/ssl/certs/${::fqdn}.pem",
         'ssl_key'                 =>
           "/etc/puppetlabs/puppet/ssl/private_keys/${::fqdn}.pem",
       }
@@ -59,7 +59,7 @@ class profile::services::mysql::standalone {
     package_name    => 'mariadb-client',
   }
 
-  Apt::Source['mariadb'] ~>
-  Class['apt::update'] ->
-  Class['mysql::server']
+  Apt::Source['mariadb']
+  ~> Class['apt::update']
+  -> Class['mysql::server']
 }

--- a/manifests/services/mysql/standalone.pp
+++ b/manifests/services/mysql/standalone.pp
@@ -12,6 +12,10 @@ class profile::services::mysql::standalone {
     'value_type'    => Integer,
     'default_value' => 60,
   })
+  $innodb_buffer_pool_size = lookup('profile::mysql::innodb_buffer_pool_size', {
+    'default_value' => 1073741824, # We default to 1GB. 
+    'value_type'    => Integer, 
+  })
 
   $zabbix_servers = lookup('profile::zabbix::agent::servers', {
     'default_value' => [],
@@ -34,15 +38,18 @@ class profile::services::mysql::standalone {
     root_password           => $rootpassword,
     remove_default_accounts => true,
     override_options        => {
-      'mysqld'              => {
-        'port'              => '3306',
-        'bind-address'      => $::sl2['server']['primary_interface']['ipv4'], 
-        'max_connections'   => '750',
-        'net_read_timeout'  => $net_read_timeout,
-        'net_write_timeout' => $net_write_timeout,
-        'ssl_ca'            => '/etc/puppetlabs/puppet/ssl/certs/ca.pem',
-        'ssl_cert'          => "/etc/puppetlabs/puppet/ssl/certs/${fqdn}.pem",
-        'ssl_key'           =>
+      'mysqld'                    => {
+        'port'                    => '3306',
+        'bind-address'            => 
+          $::sl2['server']['primary_interface']['ipv4'], 
+        'innodb_buffer_pool_size' => $innodb_buffer_pool_size, 
+        'max_connections'         => '750',
+        'net_read_timeout'        => $net_read_timeout,
+        'net_write_timeout'       => $net_write_timeout,
+        'ssl_ca'                  => '/etc/puppetlabs/puppet/ssl/certs/ca.pem',
+        'ssl_cert'                => 
+          "/etc/puppetlabs/puppet/ssl/certs/${fqdn}.pem",
+        'ssl_key'                 =>
           "/etc/puppetlabs/puppet/ssl/private_keys/${::fqdn}.pem",
       }
     },


### PR DESCRIPTION
This tuning of the MySQL-clusters provides us with:

- A lot better read-performance in large databases
- Better write-performance, due to fewer reads hitting our disks.
- More time to recover failed galera-servers without needing to do a full resync.

### New hiera-keys:

- `profile::mysql::innodb_buffer_pool_size`: Increase the default pool-size a good bit, and allow setting it in hiera if we need a further increase.
- `profile::mysql::thread_handling`: Allows us to override this setting through hiera.
- `profile::mysql::thread_pool_size`: Allows us to override this setting through hiera.
- `profile::mysql::key_buffer_size`: Increse the default buffer and allows us to override this setting through hiera.
- `profile::mysql::max_heap_table_size`: Increse the default buffer and allows us to override this setting through hiera.
- `profile::mysql::tmp_table_size`: Increse the default buffer and allows us to override this setting through hiera.
- `profile::mysql::wsrep::gcache`: Increse the default buffer and allows us to override this setting through hiera.