### PR TITLE
Match the correct start of the line instead of just looking for 4 numbers

### DIFF
--- a/files/uefi/uefi-bootorder-set.sh
+++ b/files/uefi/uefi-bootorder-set.sh
@@ -5,8 +5,8 @@ primary="NIC"
 secondary="ubuntu"
 
 order=$(efibootmgr | grep "BootOrder:" | cut -f 2 -d ' ')
-primaryID=$(efibootmgr | grep $primary | grep -Po '^.*\K[0-9]{4}' | tr '\n' ',' | sed 's/,$//g')
-secondaryID=$(efibootmgr | grep $secondary | grep -Po '^.*\K[0-9]{4}' | tr '\n' ',' | sed 's/,$//g')
+primaryID=$(efibootmgr | grep $primary | grep -Po '^Boot\K[0-9]{4}' | tr '\n' ',' | sed 's/,$//g')
+secondaryID=$(efibootmgr | grep $secondary | grep -Po '^Boot\K[0-9]{4}' | tr '\n' ',' | sed 's/,$//g')
 
 if [[ -z $order || -z $primaryID || -z $secondaryID ]]; then
   echo "Failed to detect boot-order"

--- a/files/uefi/uefi-bootorder-verify.sh
+++ b/files/uefi/uefi-bootorder-verify.sh
@@ -5,8 +5,8 @@ primary="NIC"
 secondary="ubuntu"
 
 order=$(efibootmgr | grep "BootOrder:" | cut -f 2 -d ' ')
-primaryID=$(efibootmgr | grep $primary | grep -Po '^.*\K[0-9]{4}' | tr '\n' ',' | sed 's/,$//g')
-secondaryID=$(efibootmgr | grep $secondary | grep -Po '^.*\K[0-9]{4}' | tr '\n' ',' | sed 's/,$//g')
+primaryID=$(efibootmgr | grep $primary | grep -Po '^Boot\K[0-9]{4}' | tr '\n' ',' | sed 's/,$//g')
+secondaryID=$(efibootmgr | grep $secondary | grep -Po '^Boot\K[0-9]{4}' | tr '\n' ',' | sed 's/,$//g')
 
 if [[ -z $order || -z $primaryID || -z $secondaryID ]]; then
   echo "Failed to detect boot-order"


### PR DESCRIPTION
This merge fixes the boot-order script so it works no newer machines where the NIC-line also includes an UUID.