### PR TITLE
Puppetdbtermini

### DIFF
--- a/manifests/services/puppet/db/firewall.pp
+++ b/manifests/services/puppet/db/firewall.pp
@@ -1,6 +1,6 @@
 # Configures the firewall for puppetmasters. 
 class profile::services::puppet::db::firewall {
-  ::profile::firewall::infra::region { 'PuppetDB':
+  ::profile::firewall::infra::all { 'PuppetDB':
     port => 8081,
   }
 }

--- a/manifests/services/puppet/server/install.pp
+++ b/manifests/services/puppet/server/install.pp
@@ -12,6 +12,12 @@ class profile::services::puppet::server::install {
     name   => $package,
   }
 
+  if($package == 'openvox-server') {
+    package { 'openvoxdb-termini':
+      ensure => 'present',
+    }
+  }
+
   class { 'r10k':
     remote => $r10krepo,
   }


### PR DESCRIPTION
Allow inter-region access to puppetdb, and install a missing package for the puppetdb-termini when using openvox.