### PR TITLE
Fix for newer nvidia drivers

### DIFF
--- a/files/zabbix/zabbix_vgpu.py
+++ b/files/zabbix/zabbix_vgpu.py
@@ -42,6 +42,8 @@ def parseNvidiaSMI():
       value = value.rstrip().lstrip()
       if(len(value) == 0):
         raise ValueError
+      if(key == "GPU"):
+          key = "Gpu"
       if(key == "vGPU ID"):
         if("VGPUs" not in current):
           current["VGPUs"] = {}


### PR DESCRIPTION
The newest nvidia drivers has started uppercase "GPU" in the Utilization data. Override this, so that our Zabbix template still works.